### PR TITLE
be explicity when you call terms.data.frame

### DIFF
--- a/R/model-frame.R
+++ b/R/model-frame.R
@@ -97,6 +97,10 @@ model_frame <- function(formula, data) {
 
 }
 
+terms.data.frame <- function (x, ...) {
+  attr(x, "terms")
+}
+
 validate_is_formula <- function(formula) {
   validate_is(formula, rlang::is_formula, "formula")
 }


### PR DESCRIPTION
Here is a fix for issue https://github.com/tidymodels/hardhat/issues/155
If you are assuming that terms on a data.frame always calls stats::terms.default while 
- nowhere in the documentation of ?stats::terms it is indicated that you can call it on a data.frame without using terms.default 
- nor is terms.data.frame implemented in package stats
It might be better that you make your assumptions explicit. So that you don't claim terms.data.frame for other packages.
This fixes the issue for user @LasWin
All the best.