### PR TITLE
Fix for False Identification of an Interaction on LHS in `mold()`

### DIFF
--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -886,7 +886,7 @@ detect_interactions <- function(.formula) {
   terms_nms <- colnames(terms_matrix)
 
   # All interactions (*, ^, %in%) will be expanded to `:`
-  has_interactions <- grepl(":", terms_nms)
+  has_interactions <- grepl("(?<!:):(?!:)", terms_nms, perl = TRUE)
 
   has_any_interactions <- any(has_interactions)
 


### PR DESCRIPTION
Pull Request closes #173

Fix allows users to use a package prefix for a function on the LHS of the formula in `mold()`, e.g. `mold(survival::Surv(time, status) ~ age, data = survival::lung)`

Previously, the code checked for a colon in the terms. I updated it to use lookahead and lookbehind regular expressions to search for a colon that is neither preceded nor followed by another colon.

Thank you