### PR TITLE
Use `expr_contains()` to better check for factor names in functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # hardhat (development version)
 
+* When `indicators = "none"`, `mold()` no longer misinterprets factor columns
+  as being part of an inline function if there is a similarly named non-factor
+  column also present (#182).
+
 * Moved `tune()` from tune to hardhat (#181).
 
 * `mold()` no longer misinterprets `::` as an interaction term (#174).

--- a/tests/testthat/test-mold-formula.R
+++ b/tests/testthat/test-mold-formula.R
@@ -115,7 +115,7 @@ test_that("can mold and not expand dummies", {
   expect_equal(x$blueprint$indicators, "none")
 })
 
-test_that("errors are thrown if `indicator = FALSE` and factor interactions exist", {
+test_that("errors are thrown if `indicator = 'none'` and factor interactions exist", {
 
   expect_error(
     mold(~ fac_1, example_train, blueprint = default_formula_blueprint(indicators = "none")),
@@ -185,7 +185,7 @@ test_that("errors are thrown if `indicator = FALSE` and factor interactions exis
 
 })
 
-test_that("errors are thrown if `indicator = FALSE` and factors are used in inline functions", {
+test_that("errors are thrown if `indicator = 'none'` and factors are used in inline functions", {
 
   blueprint_no_indicators <- default_formula_blueprint(indicators = "none")
 
@@ -216,6 +216,28 @@ test_that("errors are thrown if `indicator = FALSE` and factors are used in inli
     "'fac_1', 'fac_12'."
   )
 
+})
+
+test_that("`indicators = 'none'` doesn't error if a non-factor name regex-matches a factor name (#182)", {
+  df <- vctrs::data_frame(y = 1:2, x = factor(c("a", "b")), x2 = c(2, 3))
+
+  blueprint_no_indicators <- default_formula_blueprint(indicators = "none")
+
+  out <- mold(y ~ x + x2, df, blueprint = blueprint_no_indicators)
+
+  expect_identical(out$predictors$x, df$x)
+  expect_identical(out$predictors$x2, df$x2)
+})
+
+test_that("`indicators = 'none'` doesn't error if an inline function regex-matches a factor name (#182)", {
+  df <- vctrs::data_frame(y = 1:2, identity = factor(c("a", "b")), x2 = c(2, 3))
+
+  blueprint_no_indicators <- default_formula_blueprint(indicators = "none")
+
+  out <- mold(y ~ identity + identity(x2), df, blueprint = blueprint_no_indicators)
+
+  expect_identical(out$predictors$`identity(x2)`, df$x2)
+  expect_identical(out$predictors$identity, df$identity)
 })
 
 test_that("`indicators = 'none'` works fine in strange formulas", {


### PR DESCRIPTION
Closes #182 
Related to #175, as we also used `expr_contains()` there

In the original example in #182, we would detect `species` as a factor column, and then in `detect_factorish_in_functions()` we would `grepl()` that against the non-factor expressions in the terms object, which included the expression that was just: `xxspeciesxx`, so it looked like `species` was part of an inline function.

We no longer use `grepl()`, instead moving to the (hopefully) more robust approach of iterating through the components of the expression with `expr_contains()` and checking them exactly.

We modified `expr_contains()` here to disallow matching function names in case a user has a factor column that is named the same as an inline function they used. This should be rare anyways, but seemed like a good check. We didn't have this before because we were checking for `:`, which was the actual function name.