### PR TITLE
Remove unnecessary `as_tibble` calls

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
 library(hardhat)
 
+
 test_check("hardhat")


### PR DESCRIPTION
This pull request addresses issue #222 by removing unnecessary `as_tibble` calls.

Changes made:

+ Added unit test of `check_is_data_like` in newly-created `test-util.R` to validate behavior
+ Removed `as_tibble` call in `model_frame` as it repeats logic performed in `check_is_data_like` that coerces the first parameter to a tibble.


`as_tibble` occurs 7 times in the code as of the time of this comment at [commit c2c896cf1141883533ce5d4ad37e80fd6284c92a](https://github.com/tidymodels/hardhat/tree/c2c896cf1141883533ce5d4ad37e80fd6284c92a). To remove redundant calls we will examine the following uses:

1. `model_frame` in [`R/model-frame.R`](https://github.com/tidymodels/hardhat/blob/main/R/model-frame.R): 
+ The `data` parameter is passed through the `check_is_data_lake`. For `check_is_data_like` to succeed the `data` parameter must be either a `data.frame` or `matrix`
+ I added tests in `test-util.R` that confirms the behavior of 