### PR TITLE
Use `update_blueprint0()` internally for performance

### DIFF
--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -397,7 +397,7 @@ mold_formula_default_clean <- function(blueprint, data) {
   formula <- remove_formula_intercept(blueprint$formula, blueprint$intercept)
   formula <- alter_formula_environment(formula)
 
-  blueprint <- update_blueprint(blueprint, formula = formula)
+  blueprint <- update_blueprint0(blueprint, formula = formula)
 
   new_mold_clean(blueprint, data)
 }
@@ -513,12 +513,12 @@ mold_formula_default_process <- function(blueprint, data) {
 
   # nuke formula environment before returning
   formula_empty_env <- nuke_formula_environment(blueprint$formula)
-  blueprint <- update_blueprint(blueprint, formula = formula_empty_env)
+  blueprint <- update_blueprint0(blueprint, formula = formula_empty_env)
 
   ptypes <- new_ptypes(predictors_ptype, outcomes_ptype)
   extras <- new_extras(predictors_extras, outcomes_extras)
 
-  blueprint <- update_blueprint(blueprint, ptypes = ptypes)
+  blueprint <- update_blueprint0(blueprint, ptypes = ptypes)
 
   new_mold_process(predictors, outcomes, blueprint, extras)
 }
@@ -548,7 +548,7 @@ mold_formula_default_process_predictors <- function(blueprint, data) {
     levels <- list()
   }
 
-  blueprint <- update_blueprint(blueprint, levels = levels)
+  blueprint <- update_blueprint0(blueprint, levels = levels)
 
   if (identical(blueprint$indicators, "none")) {
     factorish_names <- extract_original_factorish_names(ptype)
@@ -584,7 +584,7 @@ mold_formula_default_process_predictors <- function(blueprint, data) {
 
   blueprint_terms <- blueprint$terms
   blueprint_terms$predictors <- terms
-  blueprint <- update_blueprint(blueprint, terms = blueprint_terms)
+  blueprint <- update_blueprint0(blueprint, terms = blueprint_terms)
 
   new_mold_process_terms(
     blueprint = blueprint,
@@ -615,7 +615,7 @@ mold_formula_default_process_outcomes <- function(blueprint, data) {
 
   blueprint_terms <- blueprint$terms
   blueprint_terms$outcomes <- terms
-  blueprint <- update_blueprint(blueprint, terms = blueprint_terms)
+  blueprint <- update_blueprint0(blueprint, terms = blueprint_terms)
 
   new_mold_process_terms(
     blueprint = blueprint,

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -223,7 +223,7 @@ mold_recipe_default_process <- function(blueprint, data) {
     fresh = blueprint$fresh,
     strings_as_factors = blueprint_strings_as_factors(blueprint)
   )
-  blueprint <- update_blueprint(blueprint, recipe = recipe)
+  blueprint <- update_blueprint0(blueprint, recipe = recipe)
 
   processed <- mold_recipe_default_process_predictors(blueprint = blueprint, data = data)
 
@@ -250,11 +250,11 @@ mold_recipe_default_process <- function(blueprint, data) {
   )
 
   # un-retain training data
-  blueprint <- update_blueprint(blueprint, recipe = compost(blueprint$recipe))
+  blueprint <- update_blueprint0(blueprint, recipe = compost(blueprint$recipe))
 
   ptypes <- new_ptypes(predictors_ptype, outcomes_ptype)
 
-  blueprint <- update_blueprint(blueprint, ptypes = ptypes)
+  blueprint <- update_blueprint0(blueprint, ptypes = ptypes)
 
   new_mold_process(predictors, outcomes, blueprint, extras)
 }
@@ -304,7 +304,7 @@ mold_recipe_default_process_extras <- function(blueprint, data) {
   if (!is.null(original_extra_role_cols)) {
     original_extra_role_ptypes <- lapply(original_extra_role_cols, extract_ptype)
 
-    blueprint <- update_blueprint(
+    blueprint <- update_blueprint0(
       blueprint,
       extra_role_ptypes = original_extra_role_ptypes
     )

--- a/R/blueprint-xy-default.R
+++ b/R/blueprint-xy-default.R
@@ -243,7 +243,7 @@ mold_xy_default_process <- function(blueprint, x, y) {
   ptypes <- new_ptypes(predictors_ptype, outcomes_ptype)
   extras <- new_extras(predictors_extras, outcomes_extras)
 
-  blueprint <- update_blueprint(blueprint, ptypes = ptypes)
+  blueprint <- update_blueprint0(blueprint, ptypes = ptypes)
 
   new_mold_process(predictors, outcomes, blueprint, extras)
 }

--- a/R/mold.R
+++ b/R/mold.R
@@ -93,7 +93,7 @@ mold.formula <- function(formula, data, ..., blueprint = NULL) {
 
   check_formula_blueprint(blueprint)
 
-  blueprint <- update_blueprint(blueprint = blueprint, formula = formula)
+  blueprint <- update_blueprint0(blueprint, formula = formula)
 
   run_mold(blueprint, data = data)
 }
@@ -109,7 +109,7 @@ mold.recipe <- function(x, data, ..., blueprint = NULL) {
 
   check_recipe_blueprint(blueprint)
 
-  blueprint <- update_blueprint(blueprint = blueprint, recipe = x)
+  blueprint <- update_blueprint0(blueprint, recipe = x)
 
   run_mold(blueprint, data = data)
 }


### PR DESCRIPTION
Because the `check_*()` functions have a decent amount of overhead when called a lot, and we don't really need it for this internal usage