### PR TITLE
Add home-grown `with_na_pass()` for now

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hardhat (development version)
 
+* `mold()` and `forge()` generally have less overhead (#235, #236).
+
 * Using a formula blueprint with `indicators = "none"` and character predictors
   now works properly if you provide a character column that only contains a
   single value (#213).

--- a/R/model-frame.R
+++ b/R/model-frame.R
@@ -78,9 +78,8 @@ model_frame <- function(formula, data) {
   check_data_frame_or_matrix(data)
   data <- coerce_to_tibble(data)
 
-  frame <- with_options(
-    stats::model.frame(formula, data = data),
-    na.action = "na.pass"
+  frame <- with_na_pass(
+    stats::model.frame(formula, data = data)
   )
 
   # Can't simplify terms env here, sometimes we need it to exist

--- a/R/model-matrix.R
+++ b/R/model-matrix.R
@@ -87,9 +87,8 @@ model_matrix <- function(terms, data) {
   # actually error out if we don't prevent it from running
   attr(data, "terms") <- terms
 
-  predictors <- with_options(
-    model.matrix(object = terms, data = data),
-    na.action = "na.pass"
+  predictors <- with_na_pass(
+    model.matrix(object = terms, data = data)
   )
 
   predictors <- strip_model_matrix(predictors)

--- a/R/util.R
+++ b/R/util.R
@@ -196,6 +196,17 @@ hardhat_new_tibble <- function (x, size) {
 
 # ------------------------------------------------------------------------------
 
+with_na_pass <- function(expr) {
+  # TODO: This helper is only used because `withr::defer()` is somewhat slow
+  # right now. Remove this helper and use `rlang::with_options()` once the next
+  # version of withr/rlang is on CRAN https://github.com/r-lib/withr/pull/221.
+  old <- options(na.action = "na.pass")
+  on.exit(options(old), add = TRUE, after = FALSE)
+  expr
+}
+
+# ------------------------------------------------------------------------------
+
 check_inherits <- function(x,
                            what,
                            ...,


### PR DESCRIPTION
To be removed once withr/rlang is released with the faster version of `defer()` and `with_options()`, see https://github.com/r-lib/withr/pull/221

``` r
library(hardhat)
library(tibble)

formula <- y ~ a + b

df1 <- data.frame(y = 1, a = 2, b = 3)
df2 <- tibble(y = 1, a = 2, b = 3)

bench::mark(mold(formula, df1), iterations = 10000)
# Main
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mold(formula, df1)   1.33ms   1.73ms      578.    1.74MB     12.0

# This PR
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mold(formula, df1)    998µs   1.14ms      828.    1.74MB     12.6

bench::mark(mold(formula, df2), iterations = 10000)
# Main
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mold(formula, df2)   1.38ms   1.65ms      590.    2.77KB     13.0

# This PR
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mold(formula, df2)    972µs   1.19ms      805.        0B     12.9


x <- mold(formula, df1)
bench::mark(forge(df1, x$blueprint), iterations = 10000)
# Main
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 forge(df1, x$blueprint)    793µs    992µs      985.     352KB     13.3

# This PR
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 forge(df1, x$blueprint)    596µs    724µs     1296.     350KB     12.3

x <- mold(formula, df2)
bench::mark(forge(df2, x$blueprint), iterations = 10000)
# Main
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 forge(df2, x$blueprint)    823µs    995µs      979.    1.84KB     13.2

# This PR
#> # A tibble: 1 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 forge(df2, x$blueprint)    567µs    665µs     1432.        0B     13.6
```

<sup>Created on 2023-03-27 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>