### PR TITLE
Missing snapshots

### DIFF
--- a/tests/testthat/_snaps/blueprint-formula-default.md
+++ b/tests/testthat/_snaps/blueprint-formula-default.md
@@ -1,0 +1,24 @@
+# `levels` argument is validated
+
+    Code
+      new_default_formula_blueprint(levels = 1)
+    Condition
+      Error in `new_default_formula_blueprint()`:
+      ! `levels` must be a list, not the number 1.
+
+---
+
+    Code
+      new_default_formula_blueprint(levels = list(1))
+    Condition
+      Error in `new_default_formula_blueprint()`:
+      ! `levels` must be fully named.
+
+---
+
+    Code
+      new_default_formula_blueprint(levels = list(a = 1))
+    Condition
+      Error in `new_default_formula_blueprint()`:
+      ! `levels` must only contain character vectors.
+

--- a/tests/testthat/_snaps/blueprint.md
+++ b/tests/testthat/_snaps/blueprint.md
@@ -1,3 +1,11 @@
+# check on input to `new_blueprint()`
+
+    Code
+      new_blueprint(same_new_arg = 1, same_new_arg = 2)
+    Condition
+      Error in `new_blueprint()`:
+      ! All elements of `...` must have unique names.
+
 # checks for updating a blueprint
 
     Code

--- a/tests/testthat/_snaps/blueprint.md
+++ b/tests/testthat/_snaps/blueprint.md
@@ -1,0 +1,41 @@
+# checks for updating a blueprint
+
+    Code
+      update_blueprint(blueprint, intercept = TRUE, intercept = FALSE)
+    Condition
+      Error in `update_blueprint()`:
+      ! `...` must have unique names.
+
+---
+
+    Code
+      update_blueprint(blueprint, intercpt = TRUE)
+    Condition
+      Error in `update_blueprint()`:
+      ! All elements of `...` must already exist.
+      i The following fields are new: "intercpt".
+
+# checks the ptype
+
+    Code
+      new_blueprint(ptypes = list(x = 1))
+    Condition
+      Error in `new_blueprint()`:
+      ! `ptypes` must have an element named "predictors".
+
+---
+
+    Code
+      new_blueprint(ptypes = list(predictors = "not a tibble", outcomes = "not a tibble"))
+    Condition
+      Error in `new_blueprint()`:
+      ! `ptypes$predictors` must be a tibble, not the string "not a tibble".
+
+---
+
+    Code
+      new_blueprint(ptypes = list(predictors = tibble_too_long, outcomes = tibble_too_long))
+    Condition
+      Error in `new_blueprint()`:
+      ! `ptypes$predictors` must be size 0, not size 1.
+

--- a/tests/testthat/_snaps/model-matrix.md
+++ b/tests/testthat/_snaps/model-matrix.md
@@ -1,0 +1,38 @@
+# `contr_one_hot()` input checks
+
+    Code
+      contr_one_hot(n = 1, sparse = TRUE)
+    Condition
+      Warning:
+      `sparse = TRUE` not implemented for `contr_one_hot()`.
+    Output
+        1
+      1 1
+
+---
+
+    Code
+      contr_one_hot(n = 1, contrasts = FALSE)
+    Condition
+      Warning:
+      `contrasts = FALSE` not implemented for `contr_one_hot()`.
+    Output
+        1
+      1 1
+
+---
+
+    Code
+      contr_one_hot(n = 1:2)
+    Condition
+      Error in `contr_one_hot()`:
+      ! `n` must have length 1 when an integer is provided.
+
+---
+
+    Code
+      contr_one_hot(n = list(1:2))
+    Condition
+      Error in `contr_one_hot()`:
+      ! `n` must be a character vector or an integer of size 1.
+

--- a/tests/testthat/test-blueprint-formula-default.R
+++ b/tests/testthat/test-blueprint-formula-default.R
@@ -1,0 +1,11 @@
+test_that("`levels` argument is validated", {
+  expect_snapshot(error = TRUE, {
+    new_default_formula_blueprint(levels = 1)
+  })
+  expect_snapshot(error = TRUE, {
+    new_default_formula_blueprint(levels = list(1))
+  })
+  expect_snapshot(error = TRUE, {
+    new_default_formula_blueprint(levels = list("a" = 1))
+  })
+})

--- a/tests/testthat/test-blueprint.R
+++ b/tests/testthat/test-blueprint.R
@@ -1,0 +1,24 @@
+test_that("checks for updating a blueprint", {
+  blueprint <- default_xy_blueprint()
+
+  expect_snapshot(error = TRUE, {
+    update_blueprint(blueprint, intercept = TRUE, intercept = FALSE)
+  })
+  expect_snapshot(error = TRUE, {
+    update_blueprint(blueprint, intercpt = TRUE)
+  })
+})
+
+test_that("checks the ptype", {
+  expect_snapshot(error = TRUE, {
+    new_blueprint(ptypes = list(x = 1))
+  })
+  expect_snapshot(error = TRUE, {
+    new_blueprint(ptypes = list("predictors" = "not a tibble", outcomes = "not a tibble"))
+  })
+
+  tibble_too_long <- tibble::tibble(x =1)
+  expect_snapshot(error = TRUE, {
+    new_blueprint(ptypes = list("predictors" = tibble_too_long, outcomes = tibble_too_long))
+  })
+})

--- a/tests/testthat/test-blueprint.R
+++ b/tests/testthat/test-blueprint.R
@@ -1,3 +1,9 @@
+test_that("check on input to `new_blueprint()`", {
+  expect_snapshot(error = TRUE, {
+    new_blueprint(same_new_arg = 1, same_new_arg = 2)
+  })
+})
+
 test_that("checks for updating a blueprint", {
   blueprint <- default_xy_blueprint()
 

--- a/tests/testthat/test-model-matrix.R
+++ b/tests/testthat/test-model-matrix.R
@@ -13,3 +13,14 @@ test_that("`model_matrix()` strips all attributes from the `model.matrix()` resu
   # attached "assign" and "contrasts" attributes here
   expect_identical(matrix$Speciessetosa, expect)
 })
+
+test_that("`contr_one_hot()` input checks", {
+  expect_snapshot(contr_one_hot(n = 1, sparse = TRUE))
+  expect_snapshot(contr_one_hot(n = 1, contrasts = FALSE))
+  expect_snapshot(error = TRUE, {
+    contr_one_hot(n = 1:2)
+  })
+  expect_snapshot(error = TRUE, {
+    contr_one_hot(n = list(1:2))
+  })
+})


### PR DESCRIPTION
```
library(tidyverse)

# https://github.com/r-lib/covr/issues/482
res_tbl <- devtools::test_coverage() |>
  purrr::map(~tibble(
    value = if_else(is.null(.x$value), NA, .x$value), 
    code = as.character(.x$srcref)
  )) |>
  purrr::list_rbind(names_to = "file")

res_tbl |>
  filter(value == 0, str_detect(code, "(cli_abort|cli_warn|cli_inform|abort|warn)")) |>
  arrange(file) |>
  mutate(file = str_extract(file, ".*?:.*?:")) |>
  mutate(file = str_remove(file, ":$")) |>
  pull(file) |>
  cat(sep = "\n")
```
gives
```
use.R:130
use.R:134
util.R:17
```
but the two in `use.R` are tested in 
https://github.com/tidymodels/hardhat/blob/92ad3919f982f751f206851d2b4b7ed6849056b9/tests/testthat/test-use.R#L64-L68
and for the one in `util.R` I opened #267