### PR TITLE
Threading the call through

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Added a new vector class called `quantile_pred()` to house predictions made from a quantile regression model (tidymodels/parsnip#1191, @dajmcdon). 
 
+* Several functions gained a `call` argument for passing the call used in errors and warnings (#275).
+
 # hardhat 1.4.0
 
 * Added `extract_postprocessor()` generic (#247).

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -565,7 +565,7 @@ mold_formula_default_process_predictors <- function(blueprint, data, ..., call =
   }
 
   framed <- model_frame(formula, data)
-  offset <- extract_offset(framed$terms, framed$data)
+  offset <- extract_offset(framed$terms, framed$data, call = call)
 
   if (identical(blueprint$indicators, "one_hot")) {
     predictors <- model_matrix_one_hot(
@@ -765,7 +765,7 @@ forge_formula_default_process_predictors <- function(blueprint, predictors, ...,
 
   data <- recompose(data, composition = blueprint$composition, call = call)
 
-  offset <- extract_offset(framed$terms, framed$data)
+  offset <- extract_offset(framed$terms, framed$data, call = call)
 
   extras <- list(offset = offset)
 

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -506,7 +506,8 @@ mold_formula_default_process <- function(blueprint, data, ..., call = caller_env
 
   processed <- mold_formula_default_process_outcomes(
     blueprint = blueprint,
-    data = data
+    data = data,
+    call = call
   )
 
   blueprint <- processed$blueprint
@@ -599,10 +600,12 @@ mold_formula_default_process_predictors <- function(blueprint, data, ..., call =
   )
 }
 
-mold_formula_default_process_outcomes <- function(blueprint, data) {
+mold_formula_default_process_outcomes <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   formula <- blueprint$formula
 
-  original_names <- get_all_outcomes(formula, data)
+  original_names <- get_all_outcomes(formula, data, call = call)
   data <- data[original_names]
 
   ptype <- extract_ptype(data)

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -372,7 +372,7 @@ refresh_blueprint.default_formula_blueprint <- function(blueprint) {
 #'
 #' @rdname run-mold
 #' @export
-run_mold.default_formula_blueprint <- function(blueprint, ..., data) {
+run_mold.default_formula_blueprint <- function(blueprint, ..., data, call = caller_env()) {
   check_dots_empty0(...)
 
   cleaned <- mold_formula_default_clean(blueprint = blueprint, data = data)
@@ -380,7 +380,7 @@ run_mold.default_formula_blueprint <- function(blueprint, ..., data) {
   blueprint <- cleaned$blueprint
   data <- cleaned$data
 
-  mold_formula_default_process(blueprint = blueprint, data = data)
+  mold_formula_default_process(blueprint = blueprint, data = data, call = call)
 }
 
 # ------------------------------------------------------------------------------
@@ -490,10 +490,13 @@ recurse_intercept_search <- function(x,
 # ------------------------------------------------------------------------------
 # mold - formula - process
 
-mold_formula_default_process <- function(blueprint, data) {
+mold_formula_default_process <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   processed <- mold_formula_default_process_predictors(
     blueprint = blueprint,
-    data = data
+    data = data,
+    call = call
   )
 
   blueprint <- processed$blueprint
@@ -523,7 +526,9 @@ mold_formula_default_process <- function(blueprint, data) {
   new_mold_process(predictors, outcomes, blueprint, extras)
 }
 
-mold_formula_default_process_predictors <- function(blueprint, data) {
+mold_formula_default_process_predictors <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   formula <- expand_formula_dot_notation(blueprint$formula, data)
   formula <- get_predictors_formula(formula)
 
@@ -580,7 +585,7 @@ mold_formula_default_process_predictors <- function(blueprint, data) {
 
   terms <- simplify_terms(framed$terms)
 
-  predictors <- recompose(predictors, composition = blueprint$composition)
+  predictors <- recompose(predictors, composition = blueprint$composition, call = call)
 
   blueprint_terms <- blueprint$terms
   blueprint_terms$predictors <- terms

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -657,7 +657,8 @@ run_forge.default_formula_blueprint <- function(blueprint,
     blueprint = blueprint,
     predictors = predictors,
     outcomes = outcomes,
-    extras = extras
+    extras = extras,
+    call = call
   )
 }
 
@@ -702,10 +703,13 @@ forge_formula_default_clean <- function(blueprint, new_data, outcomes, ..., call
 
 # ------------------------------------------------------------------------------
 
-forge_formula_default_process <- function(blueprint, predictors, outcomes, extras) {
+forge_formula_default_process <- function(blueprint, predictors, outcomes, extras, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   processed <- forge_formula_default_process_predictors(
     blueprint = blueprint,
-    predictors = predictors
+    predictors = predictors,
+    call = call
   )
 
   blueprint <- processed$blueprint
@@ -729,7 +733,9 @@ forge_formula_default_process <- function(blueprint, predictors, outcomes, extra
   new_forge_process(predictors, outcomes, extras)
 }
 
-forge_formula_default_process_predictors <- function(blueprint, predictors) {
+forge_formula_default_process_predictors <- function(blueprint, predictors, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   terms <- blueprint$terms$predictors
   terms <- alter_terms_environment(terms)
 
@@ -757,7 +763,7 @@ forge_formula_default_process_predictors <- function(blueprint, predictors) {
     data <- unmask_factorish_in_data(data, factorish_predictors)
   }
 
-  data <- recompose(data, composition = blueprint$composition)
+  data <- recompose(data, composition = blueprint$composition, call = call)
 
   offset <- extract_offset(framed$terms, framed$data)
 

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -532,7 +532,7 @@ mold_formula_default_process_predictors <- function(blueprint, data, ..., call =
   formula <- expand_formula_dot_notation(blueprint$formula, data)
   formula <- get_predictors_formula(formula)
 
-  original_names <- get_all_predictors(formula, data)
+  original_names <- get_all_predictors(formula, data, call = call)
   data <- data[original_names]
 
   ptype <- extract_ptype(data)
@@ -558,8 +558,8 @@ mold_formula_default_process_predictors <- function(blueprint, data, ..., call =
   if (identical(blueprint$indicators, "none")) {
     factorish_names <- extract_original_factorish_names(ptype)
     factorish_data <- data[factorish_names]
-    check_no_factorish_in_interactions(formula, factorish_names)
-    check_no_factorish_in_functions(formula, factorish_names)
+    check_no_factorish_in_interactions(formula, factorish_names, error_call = call)
+    check_no_factorish_in_functions(formula, factorish_names, error_call = call)
     formula <- remove_factorish_from_formula(formula, factorish_names)
     data <- mask_factorish_in_data(data, factorish_names)
   }

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -631,13 +631,16 @@ mold_formula_default_process_outcomes <- function(blueprint, data) {
 run_forge.default_formula_blueprint <- function(blueprint,
                                                 new_data,
                                                 ...,
-                                                outcomes = FALSE) {
+                                                outcomes = FALSE,
+                                                call = caller_env()
+                                              ) {
   check_dots_empty0(...)
 
   cleaned <- forge_formula_default_clean(
     blueprint = blueprint,
     new_data = new_data,
-    outcomes = outcomes
+    outcomes = outcomes,
+    call = call
   )
 
   blueprint <- cleaned$blueprint
@@ -655,7 +658,8 @@ run_forge.default_formula_blueprint <- function(blueprint,
 
 # ------------------------------------------------------------------------------
 
-forge_formula_default_clean <- function(blueprint, new_data, outcomes) {
+forge_formula_default_clean <- function(blueprint, new_data, outcomes, ..., call = caller_env()) {
+  check_dots_empty0(...)
   check_data_frame_or_matrix(new_data)
   new_data <- coerce_to_tibble(new_data)
   check_unique_column_names(new_data)
@@ -672,7 +676,7 @@ forge_formula_default_clean <- function(blueprint, new_data, outcomes) {
     function(col, levels) factor(col, levels = levels)
   )
 
-  predictors <- shrink(new_data, predictors_ptype)
+  predictors <- shrink(new_data, predictors_ptype, call = call)
 
   predictors <- scream(
     predictors,
@@ -681,7 +685,7 @@ forge_formula_default_clean <- function(blueprint, new_data, outcomes) {
   )
 
   if (outcomes) {
-    outcomes <- shrink(new_data, blueprint$ptypes$outcomes)
+    outcomes <- shrink(new_data, blueprint$ptypes$outcomes, call = call)
     # Never allow novel levels for outcomes
     outcomes <- scream(outcomes, blueprint$ptypes$outcomes)
   } else {

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -614,7 +614,7 @@ mold_formula_default_process_outcomes <- function(blueprint, data, ..., call = c
   formula <- get_outcomes_formula(formula)
 
   # used on the `~ LHS` formula
-  check_no_interactions(formula)
+  check_no_interactions(formula, error_call = call)
 
   framed <- model_frame(formula, data)
 

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -386,9 +386,9 @@ run_mold.default_formula_blueprint <- function(blueprint, ..., data, call = call
 # ------------------------------------------------------------------------------
 # mold - formula - clean
 
-  check_data_frame_or_matrix(data)
 mold_formula_default_clean <- function(blueprint, data, ..., call = caller_env()) {
   check_dots_empty0(...)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   # Check here, not in the constructor, because we

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -375,7 +375,7 @@ refresh_blueprint.default_formula_blueprint <- function(blueprint) {
 run_mold.default_formula_blueprint <- function(blueprint, ..., data, call = caller_env()) {
   check_dots_empty0(...)
 
-  cleaned <- mold_formula_default_clean(blueprint = blueprint, data = data)
+  cleaned <- mold_formula_default_clean(blueprint = blueprint, data = data, call = call)
 
   blueprint <- cleaned$blueprint
   data <- cleaned$data
@@ -386,13 +386,14 @@ run_mold.default_formula_blueprint <- function(blueprint, ..., data, call = call
 # ------------------------------------------------------------------------------
 # mold - formula - clean
 
-mold_formula_default_clean <- function(blueprint, data) {
   check_data_frame_or_matrix(data)
+mold_formula_default_clean <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
   data <- coerce_to_tibble(data)
 
   # Check here, not in the constructor, because we
   # put a non-intercept-containing formula back in
-  check_implicit_intercept(blueprint$formula, arg = "formula")
+  check_implicit_intercept(blueprint$formula, arg = "formula", call = call)
 
   formula <- remove_formula_intercept(blueprint$formula, blueprint$intercept)
   formula <- alter_formula_environment(formula)

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -192,7 +192,7 @@ refresh_blueprint.default_recipe_blueprint <- function(blueprint) {
 
 #' @rdname run-mold
 #' @export
-run_mold.default_recipe_blueprint <- function(blueprint, ..., data) {
+run_mold.default_recipe_blueprint <- function(blueprint, ..., data, call = caller_env()) {
   check_dots_empty0(...)
 
   cleaned <- mold_recipe_default_clean(blueprint = blueprint, data = data)
@@ -200,7 +200,7 @@ run_mold.default_recipe_blueprint <- function(blueprint, ..., data) {
   blueprint <- cleaned$blueprint
   data <- cleaned$data
 
-  mold_recipe_default_process(blueprint = blueprint, data = data)
+  mold_recipe_default_process(blueprint = blueprint, data = data, call = call)
 }
 
 # ------------------------------------------------------------------------------
@@ -216,7 +216,8 @@ mold_recipe_default_clean <- function(blueprint, data) {
 # ------------------------------------------------------------------------------
 # mold - recipe - process
 
-mold_recipe_default_process <- function(blueprint, data) {
+mold_recipe_default_process <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
 
   # `prep()` will warn if you pass `training` data and `fresh = FALSE`
   if (is_true(blueprint$fresh)) {
@@ -234,7 +235,7 @@ mold_recipe_default_process <- function(blueprint, data) {
   )
   blueprint <- update_blueprint0(blueprint, recipe = recipe)
 
-  processed <- mold_recipe_default_process_predictors(blueprint = blueprint, data = data)
+  processed <- mold_recipe_default_process_predictors(blueprint = blueprint, data = data, call = call)
 
   blueprint <- processed$blueprint
   predictors <- processed$data
@@ -268,14 +269,16 @@ mold_recipe_default_process <- function(blueprint, data) {
   new_mold_process(predictors, outcomes, blueprint, extras)
 }
 
-mold_recipe_default_process_predictors <- function(blueprint, data) {
+mold_recipe_default_process_predictors <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   all_predictors <- recipes::all_predictors
 
   predictors <- recipes::juice(blueprint$recipe, all_predictors())
 
   predictors <- maybe_add_intercept_column(predictors, blueprint$intercept)
 
-  predictors <- recompose(predictors, composition = blueprint$composition)
+  predictors <- recompose(predictors, composition = blueprint$composition, call = call)
 
   ptype <- get_original_predictor_ptype(blueprint$recipe, data)
 

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -195,7 +195,7 @@ refresh_blueprint.default_recipe_blueprint <- function(blueprint) {
 run_mold.default_recipe_blueprint <- function(blueprint, ..., data, call = caller_env()) {
   check_dots_empty0(...)
 
-  cleaned <- mold_recipe_default_clean(blueprint = blueprint, data = data)
+  cleaned <- mold_recipe_default_clean(blueprint = blueprint, data = data, call = call)
 
   blueprint <- cleaned$blueprint
   data <- cleaned$data
@@ -206,8 +206,9 @@ run_mold.default_recipe_blueprint <- function(blueprint, ..., data, call = calle
 # ------------------------------------------------------------------------------
 # mold - recipe - clean
 
-mold_recipe_default_clean <- function(blueprint, data) {
-  check_data_frame_or_matrix(data)
+mold_recipe_default_clean <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   new_mold_clean(blueprint, data)

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -366,7 +366,8 @@ run_forge.default_recipe_blueprint <- function(blueprint,
     blueprint = blueprint,
     predictors = predictors,
     outcomes = outcomes,
-    extras = extras
+    extras = extras,
+    call = call
   )
 }
 
@@ -428,7 +429,9 @@ forge_recipe_default_clean_extras <- function(blueprint, new_data, ..., call = c
 
 # ------------------------------------------------------------------------------
 
-forge_recipe_default_process <- function(blueprint, predictors, outcomes, extras) {
+forge_recipe_default_process <- function(blueprint, predictors, outcomes, extras, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   rec <- blueprint$recipe
   vars <- rec$term_info$variable
   roles <- rec$term_info$role
@@ -465,7 +468,8 @@ forge_recipe_default_process <- function(blueprint, predictors, outcomes, extras
 
   processed <- forge_recipe_default_process_predictors(
     blueprint = blueprint,
-    predictors = predictors
+    predictors = predictors,
+    call = call
   )
 
   blueprint <- processed$blueprint
@@ -492,10 +496,12 @@ forge_recipe_default_process <- function(blueprint, predictors, outcomes, extras
   new_forge_process(predictors, outcomes, extras)
 }
 
-forge_recipe_default_process_predictors <- function(blueprint, predictors) {
+forge_recipe_default_process_predictors <- function(blueprint, predictors, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   predictors <- maybe_add_intercept_column(predictors, blueprint$intercept)
 
-  predictors <- recompose(predictors, composition = blueprint$composition)
+  predictors <- recompose(predictors, composition = blueprint$composition, call = call)
 
   new_forge_process_terms(
     blueprint = blueprint,

--- a/R/blueprint-xy-default.R
+++ b/R/blueprint-xy-default.R
@@ -305,7 +305,8 @@ run_forge.default_xy_blueprint <- function(blueprint,
     blueprint = blueprint,
     predictors = predictors,
     outcomes = outcomes,
-    extras = extras
+    extras = extras,
+    call = call
   )
 }
 
@@ -339,8 +340,10 @@ forge_xy_default_clean <- function(blueprint, new_data, outcomes, ..., call = ca
 
 # ------------------------------------------------------------------------------
 
-forge_xy_default_process <- function(blueprint, predictors, outcomes, extras) {
-  processed <- forge_xy_default_process_predictors(blueprint, predictors)
+forge_xy_default_process <- function(blueprint, predictors, outcomes, extras, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
+  processed <- forge_xy_default_process_predictors(blueprint, predictors, call = call)
 
   blueprint <- processed$blueprint
   predictors <- processed$data
@@ -360,10 +363,12 @@ forge_xy_default_process <- function(blueprint, predictors, outcomes, extras) {
   new_forge_process(predictors, outcomes, extras)
 }
 
-forge_xy_default_process_predictors <- function(blueprint, predictors) {
+forge_xy_default_process_predictors <- function(blueprint, predictors, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   predictors <- maybe_add_intercept_column(predictors, blueprint$intercept)
 
-  predictors <- recompose(predictors, composition = blueprint$composition)
+  predictors <- recompose(predictors, composition = blueprint$composition, call = call)
 
   new_forge_process_terms(
     blueprint = blueprint,

--- a/R/blueprint-xy-default.R
+++ b/R/blueprint-xy-default.R
@@ -177,7 +177,7 @@ refresh_blueprint.default_xy_blueprint <- function(blueprint) {
 #'
 #' @rdname run-mold
 #' @export
-run_mold.default_xy_blueprint <- function(blueprint, ..., x, y) {
+run_mold.default_xy_blueprint <- function(blueprint, ..., x, y, call = caller_env()) {
   check_dots_empty0(...)
 
   cleaned <- mold_xy_default_clean(blueprint = blueprint, x = x, y = y)
@@ -186,7 +186,7 @@ run_mold.default_xy_blueprint <- function(blueprint, ..., x, y) {
   x <- cleaned$x
   y <- cleaned$y
 
-  mold_xy_default_process(blueprint = blueprint, x = x, y = y)
+  mold_xy_default_process(blueprint = blueprint, x = x, y = y, call = call)
 }
 
 # ------------------------------------------------------------------------------
@@ -225,8 +225,10 @@ mold_xy_default_clean_outcomes <- function(blueprint, y) {
 # ------------------------------------------------------------------------------
 # mold - xy - process
 
-mold_xy_default_process <- function(blueprint, x, y) {
-  processed <- mold_xy_default_process_predictors(blueprint, x)
+mold_xy_default_process <- function(blueprint, x, y, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
+  processed <- mold_xy_default_process_predictors(blueprint, x, call = call)
 
   blueprint <- processed$blueprint
   predictors <- processed$data
@@ -248,14 +250,15 @@ mold_xy_default_process <- function(blueprint, x, y) {
   new_mold_process(predictors, outcomes, blueprint, extras)
 }
 
-mold_xy_default_process_predictors <- function(blueprint, x) {
+mold_xy_default_process_predictors <- function(blueprint, x, ..., call = caller_env()) {
+  check_dots_empty0(...)
 
   # Important! Collect ptype before adding intercept!
   ptype <- extract_ptype(x)
 
   x <- maybe_add_intercept_column(x, blueprint$intercept)
 
-  x <- recompose(x, composition = blueprint$composition)
+  x <- recompose(x, composition = blueprint$composition, call = call)
 
   new_mold_process_terms(
     blueprint = blueprint,

--- a/R/blueprint-xy-default.R
+++ b/R/blueprint-xy-default.R
@@ -281,13 +281,16 @@ mold_xy_default_process_outcomes <- function(blueprint, y) {
 run_forge.default_xy_blueprint <- function(blueprint,
                                            new_data,
                                            ...,
-                                           outcomes = FALSE) {
+                                           outcomes = FALSE,
+                                           call = caller_env()
+                                          ) {
   check_dots_empty0(...)
 
   cleaned <- forge_xy_default_clean(
     blueprint = blueprint,
     new_data = new_data,
-    outcomes = outcomes
+    outcomes = outcomes,
+    call = call
   )
 
   blueprint <- cleaned$blueprint
@@ -305,13 +308,14 @@ run_forge.default_xy_blueprint <- function(blueprint,
 
 # ------------------------------------------------------------------------------
 
-forge_xy_default_clean <- function(blueprint, new_data, outcomes) {
+forge_xy_default_clean <- function(blueprint, new_data, outcomes, ..., call = caller_env()) {
+  check_dots_empty0(...)
   check_data_frame_or_matrix(new_data)
   new_data <- coerce_to_tibble(new_data)
   check_unique_column_names(new_data)
   check_bool(outcomes)
 
-  predictors <- shrink(new_data, blueprint$ptypes$predictors)
+  predictors <- shrink(new_data, blueprint$ptypes$predictors, call = call)
 
   predictors <- scream(
     predictors,
@@ -320,7 +324,7 @@ forge_xy_default_clean <- function(blueprint, new_data, outcomes) {
   )
 
   if (outcomes) {
-    outcomes <- shrink(new_data, blueprint$ptypes$outcomes)
+    outcomes <- shrink(new_data, blueprint$ptypes$outcomes, call = call)
     # Never allow novel levels for outcomes
     outcomes <- scream(outcomes, blueprint$ptypes$outcomes)
   } else {

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -65,17 +65,28 @@ new_scalar <- function(elems, ..., class = character()) {
 
 # ------------------------------------------------------------------------------
 
-check_elems <- function(elems) {
+check_elems <- function(elems, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  
   if (!is.list(elems) || length(elems) == 0) {
-    cli::cli_abort("{.arg elems} must be a list of length 1 or greater.")
+    cli::cli_abort(
+      "{.arg elems} must be a list of length 1 or greater.",
+      call = call
+    )
   }
 
   if (!has_unique_names(elems)) {
-    cli::cli_abort("{.arg elems} must have unique names.")
+    cli::cli_abort(
+      "{.arg elems} must have unique names.",
+      call = call
+    )
   }
 
   if (!identical(names(attributes(elems)), "names")) {
-    cli::cli_abort("{.arg elems} must have no attributes (apart from names).")
+    cli::cli_abort(
+      "{.arg elems} must have no attributes (apart from names).",
+      call = call
+    )
   }
 
   invisible(elems)

--- a/R/forge.R
+++ b/R/forge.R
@@ -109,6 +109,7 @@ forge.matrix <- forge.data.frame
 #' then your `run_forge()` method signature must match this.
 #'
 #' @inheritParams forge
+#' @inheritParams validate_column_names
 #'
 #' @return
 #' `run_forge()` methods return the object that is then immediately returned

--- a/R/model-offset.R
+++ b/R/model-offset.R
@@ -8,6 +8,8 @@
 #' call to `model_frame()`.
 #'
 #' @param data A data frame returned from a call to `model_frame()`.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -46,7 +48,9 @@
 #'   }
 #' )
 #' @export
-model_offset <- function(terms, data) {
+model_offset <- function(terms, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   .offset_pos <- attr(terms, "offset")
 
   has_offset <- !is.null(.offset_pos)
@@ -65,7 +69,8 @@ model_offset <- function(terms, data) {
 
       cli::cli_abort(
         "Column {.val {bad_col}} is tagged as an offset and thus must be
-        numeric, not {.obj_type_friendly { .offset_val }}."
+        numeric, not {.obj_type_friendly { .offset_val }}.",
+        call = call
       )
     }
 
@@ -75,8 +80,10 @@ model_offset <- function(terms, data) {
   ans
 }
 
-extract_offset <- function(terms, data) {
-  .offset <- model_offset(terms, data)
+extract_offset <- function(terms, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
+  .offset <- model_offset(terms, data, call = call)
 
   if (is.null(.offset)) {
     NULL

--- a/R/mold.R
+++ b/R/mold.R
@@ -152,6 +152,8 @@ mold.recipe <- function(x, data, ..., blueprint = NULL) {
 #' @param blueprint A preprocessing blueprint.
 #'
 #' @param ... Not used. Required for extensibility.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #' `run_mold()` methods return the object that is then immediately returned from

--- a/R/recompose.R
+++ b/R/recompose.R
@@ -19,6 +19,8 @@
 #'   - `"matrix"` to convert to a matrix. All columns must be numeric.
 #'   - `"dgCMatrix"` to convert to a sparse matrix. All columns must be numeric,
 #'     and the Matrix package must be installed.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @returns
 #' The output type is determined from the `composition`.
@@ -37,13 +39,16 @@
 #' try(recompose(df, composition = "matrix"))
 recompose <- function(data,
                       ...,
-                      composition = "tibble") {
+                      composition = "tibble",
+                      call = caller_env()
+                    ) {
   check_dots_empty0(...)
-  check_data_frame(data)
+  check_data_frame(data, call = call)
 
   composition <- arg_match0(
     arg = composition,
-    values = c("tibble", "data.frame", "matrix", "dgCMatrix")
+    values = c("tibble", "data.frame", "matrix", "dgCMatrix"),
+    error_call = call
   )
 
   switch(
@@ -55,14 +60,14 @@ recompose <- function(data,
       new_data_frame(data, n = vec_size(data))
     },
     matrix = {
-      coerce_to_matrix(data)
+      coerce_to_matrix(data, error_call = call)
     },
     dgCMatrix = {
       if (is_sparse_tibble(data)) {
-        sparsevctrs::coerce_to_sparse_matrix(data)
+        sparsevctrs::coerce_to_sparse_matrix(data, call = call)
       } else {
-        data <- coerce_to_matrix(data)
-        coerce_to_sparse(data)
+        data <- coerce_to_matrix(data, error_call = call)
+        coerce_to_sparse(data, error_call = call)
       }
     }
   )

--- a/R/shrink.R
+++ b/R/shrink.R
@@ -13,6 +13,8 @@
 #' @param data A data frame containing the data to subset.
 #'
 #' @param ptype A data frame prototype containing the required columns.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -51,7 +53,9 @@
 #' test2 <- subset(test, select = -Species)
 #' try(shrink(test2, ptype_pred))
 #' @export
-shrink <- function(data, ptype) {
+shrink <- function(data, ptype, ..., call = current_env()) {
+  check_dots_empty0(...)
+
   if (is.null(data)) {
     return(NULL)
   }
@@ -60,7 +64,7 @@ shrink <- function(data, ptype) {
   data <- coerce_to_tibble(data)
 
   cols <- colnames(ptype)
-  validate_column_names(data, cols)
+  validate_column_names(data, cols, call = call)
 
   out <- data[cols]
 

--- a/R/standardize.R
+++ b/R/standardize.R
@@ -95,7 +95,9 @@ is_known_output_type <- function(x) {
   is.numeric(x) || is.factor(x)
 }
 
-validate_has_known_outcome_types <- function(y) {
+validate_has_known_outcome_types <- function(y, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   known <- vapply(y, is_known_output_type, logical(1))
 
   if (!all(known)) {
@@ -106,7 +108,8 @@ validate_has_known_outcome_types <- function(y) {
         "Not all columns of {.arg y} are known outcome types.",
         "i" = "{?This/These} column{?s} {?has/have} {?an/} unknown type{?s}:
               {.val {not_known}}."
-      )
+      ),
+      call = call
     )
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -47,7 +47,9 @@ get_all_predictors <- function(formula, data, ..., call = caller_env()) {
 
 # LHS `.` are NOT expanded by `expand_formula_dot_notation()`, and should be
 # considered errors
-get_all_outcomes <- function(formula, data) {
+get_all_outcomes <- function(formula, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   outcome_formula <- new_formula(
     lhs = f_lhs(formula),
     rhs = 1,
@@ -57,14 +59,18 @@ get_all_outcomes <- function(formula, data) {
   outcomes <- all.vars(outcome_formula)
 
   if ("." %in% outcomes) {
-    cli::cli_abort("The left-hand side of the formula cannot contain {.code .}.")
+    cli::cli_abort(
+      "The left-hand side of the formula cannot contain {.code .}.",
+      call = call
+    )
   }
 
   extra_outcomes <- setdiff(outcomes, names(data))
   if (length(extra_outcomes) > 0) {
     cli::cli_abort(
       "The following outcome{?s} {?was/were} not found in {.arg data}:
-      {.val {extra_outcomes}}."
+      {.val {extra_outcomes}}.",
+      call = call
     )
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -22,7 +22,9 @@ simplify_terms <- function(x) {
 # - RHS `.` should be expanded ahead of time by `expand_formula_dot_notation()`
 # - Can't use `get_all_vars()` because it chokes on formulas with variables with
 #   spaces like ~ `x y`
-get_all_predictors <- function(formula, data) {
+get_all_predictors <- function(formula, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   predictor_formula <- new_formula(
     lhs = NULL,
     rhs = f_rhs(formula),
@@ -35,7 +37,8 @@ get_all_predictors <- function(formula, data) {
   if (length(extra_predictors) > 0) {
     cli::cli_abort(
       "The following predictor{?s} {?was/were} not found in {.arg data}:
-      {.val {extra_predictors}}."
+      {.val {extra_predictors}}.",
+      call = call
     )
   }
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -436,6 +436,10 @@ check_predictors_are_numeric <- function(predictors) {
 #' @param data A data frame to check.
 #'
 #' @param original_names A character vector. The original column names.
+#' 
+#' @inheritParams rlang::args_dots_empty
+#' 
+#' @param call The call used for errors and warnings.
 #'
 #' @return
 #'
@@ -492,7 +496,9 @@ check_predictors_are_numeric <- function(predictors) {
 #' forge(test, processed$blueprint, outcomes = TRUE)
 #' @family validation functions
 #' @export
-validate_column_names <- function(data, original_names) {
+validate_column_names <- function(data, original_names, ..., call = current_env()) {
+  check_dots_empty()
+
   check_data_frame_or_matrix(data)
   data <- coerce_to_tibble(data)
 
@@ -502,7 +508,8 @@ validate_column_names <- function(data, original_names) {
     validate_missing_name_isnt_.outcome(check$missing_names)
 
     cli::cli_abort(
-      "The required column{?s} {.val {check$missing_names}} {?is/are} missing."
+      "The required column{?s} {.val {check$missing_names}} {?is/are} missing.",
+      call = call
     )
   }
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -505,7 +505,7 @@ validate_column_names <- function(data, original_names, ..., call = current_env(
   check <- check_column_names(data, original_names)
 
   if (!check$ok) {
-    validate_missing_name_isnt_.outcome(check$missing_names)
+    validate_missing_name_isnt_.outcome(check$missing_names, call = call)
 
     cli::cli_abort(
       "The required column{?s} {.val {check$missing_names}} {?is/are} missing.",
@@ -536,7 +536,9 @@ check_column_names <- function(data, original_names) {
   new_check_result(ok = ok, missing_names = missing_names)
 }
 
-validate_missing_name_isnt_.outcome <- function(missing_names) {
+validate_missing_name_isnt_.outcome <- function(missing_names, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   not_ok <- ".outcome" %in% missing_names
 
   if (not_ok) {
@@ -547,7 +549,8 @@ validate_missing_name_isnt_.outcome <- function(missing_names) {
         "i" = "When this is the case, and the outcome columns are requested in
            {.fn forge}, {.arg new_data} must include a column with the
            automatically generated name, {.code .outcome}, containing the outcome."
-      )
+      ),
+      call = call
     )
   }
 

--- a/man/model_offset.Rd
+++ b/man/model_offset.Rd
@@ -4,13 +4,17 @@
 \alias{model_offset}
 \title{Extract a model offset}
 \usage{
-model_offset(terms, data)
+model_offset(terms, data, ..., call = caller_env())
 }
 \arguments{
 \item{terms}{A \code{"terms"} object corresponding to \code{data}, returned from a
 call to \code{model_frame()}.}
 
 \item{data}{A data frame returned from a call to \code{model_frame()}.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 A numeric vector representing the offset.

--- a/man/recompose.Rd
+++ b/man/recompose.Rd
@@ -4,7 +4,7 @@
 \alias{recompose}
 \title{Recompose a data frame into another form}
 \usage{
-recompose(data, ..., composition = "tibble")
+recompose(data, ..., composition = "tibble", call = caller_env())
 }
 \arguments{
 \item{data}{A data frame.}
@@ -19,6 +19,8 @@ recompose(data, ..., composition = "tibble")
 \item \code{"dgCMatrix"} to convert to a sparse matrix. All columns must be numeric,
 and the Matrix package must be installed.
 }}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 The output type is determined from the \code{composition}.

--- a/man/run-forge.Rd
+++ b/man/run-forge.Rd
@@ -11,11 +11,11 @@
 \usage{
 run_forge(blueprint, new_data, ..., outcomes = FALSE)
 
-\method{run_forge}{default_formula_blueprint}(blueprint, new_data, ..., outcomes = FALSE)
+\method{run_forge}{default_formula_blueprint}(blueprint, new_data, ..., outcomes = FALSE, call = caller_env())
 
-\method{run_forge}{default_recipe_blueprint}(blueprint, new_data, ..., outcomes = FALSE)
+\method{run_forge}{default_recipe_blueprint}(blueprint, new_data, ..., outcomes = FALSE, call = caller_env())
 
-\method{run_forge}{default_xy_blueprint}(blueprint, new_data, ..., outcomes = FALSE)
+\method{run_forge}{default_xy_blueprint}(blueprint, new_data, ..., outcomes = FALSE, call = caller_env())
 }
 \arguments{
 \item{blueprint}{A preprocessing \code{blueprint}.}
@@ -27,6 +27,8 @@ run_forge(blueprint, new_data, ..., outcomes = FALSE)
 
 \item{outcomes}{A logical. Should the outcomes be processed and returned
 as well?}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{run_forge()} methods return the object that is then immediately returned

--- a/man/run-mold.Rd
+++ b/man/run-mold.Rd
@@ -11,11 +11,11 @@
 \usage{
 run_mold(blueprint, ...)
 
-\method{run_mold}{default_formula_blueprint}(blueprint, ..., data)
+\method{run_mold}{default_formula_blueprint}(blueprint, ..., data, call = caller_env())
 
-\method{run_mold}{default_recipe_blueprint}(blueprint, ..., data)
+\method{run_mold}{default_recipe_blueprint}(blueprint, ..., data, call = caller_env())
 
-\method{run_mold}{default_xy_blueprint}(blueprint, ..., x, y)
+\method{run_mold}{default_xy_blueprint}(blueprint, ..., x, y, call = caller_env())
 }
 \arguments{
 \item{blueprint}{A preprocessing blueprint.}
@@ -23,6 +23,8 @@ run_mold(blueprint, ...)
 \item{...}{Not used. Required for extensibility.}
 
 \item{data}{A data frame or matrix containing the outcomes and predictors.}
+
+\item{call}{The call used for errors and warnings.}
 
 \item{x}{A data frame or matrix containing the predictors.}
 

--- a/man/shrink.Rd
+++ b/man/shrink.Rd
@@ -4,12 +4,16 @@
 \alias{shrink}
 \title{Subset only required columns}
 \usage{
-shrink(data, ptype)
+shrink(data, ptype, ..., call = current_env())
 }
 \arguments{
 \item{data}{A data frame containing the data to subset.}
 
 \item{ptype}{A data frame prototype containing the required columns.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 A tibble containing the required columns.

--- a/man/validate_column_names.Rd
+++ b/man/validate_column_names.Rd
@@ -5,7 +5,7 @@
 \alias{check_column_names}
 \title{Ensure that \code{data} contains required column names}
 \usage{
-validate_column_names(data, original_names)
+validate_column_names(data, original_names, ..., call = current_env())
 
 check_column_names(data, original_names)
 }
@@ -13,6 +13,10 @@ check_column_names(data, original_names)
 \item{data}{A data frame to check.}
 
 \item{original_names}{A character vector. The original column names.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{validate_column_names()} returns \code{data} invisibly.

--- a/tests/testthat/_snaps/constructor.md
+++ b/tests/testthat/_snaps/constructor.md
@@ -34,7 +34,7 @@
     Code
       new_scalar(list())
     Condition
-      Error in `check_elems()`:
+      Error in `new_scalar()`:
       ! `elems` must be a list of length 1 or greater.
 
 # `new_scalar()` must have unique names
@@ -42,7 +42,7 @@
     Code
       new_scalar(list(x = 1, x = 2))
     Condition
-      Error in `check_elems()`:
+      Error in `new_scalar()`:
       ! `elems` must have unique names.
 
 # `new_scalar()` must have no extra attributes
@@ -50,6 +50,6 @@
     Code
       new_scalar(x)
     Condition
-      Error in `check_elems()`:
+      Error in `new_scalar()`:
       ! `elems` must have no attributes (apart from names).
 

--- a/tests/testthat/_snaps/forge-formula.md
+++ b/tests/testthat/_snaps/forge-formula.md
@@ -188,7 +188,7 @@
     Code
       mold(y ~ f, dat, blueprint = bp2)
     Condition
-      Error in `recompose()`:
+      Error in `mold()`:
       ! `data` must only contain numeric columns.
       i This column isn't numeric: "f".
 
@@ -197,7 +197,7 @@
     Code
       mold(y ~ f + f_2, dat_2f, blueprint = bp2)
     Condition
-      Error in `recompose()`:
+      Error in `mold()`:
       ! `data` must only contain numeric columns.
       i These columns aren't numeric: "f" and "f_2".
 

--- a/tests/testthat/_snaps/forge-formula.md
+++ b/tests/testthat/_snaps/forge-formula.md
@@ -3,7 +3,7 @@
     Code
       forge(example_train2, x1$blueprint, outcomes = TRUE)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "fac_1" is missing.
 
 ---
@@ -11,7 +11,7 @@
     Code
       forge(example_train2, x2$blueprint, outcomes = TRUE)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "fac_1" is missing.
 
 # new_data can only be a data frame / matrix
@@ -35,7 +35,7 @@
     Code
       forge(example_train[, 1, drop = FALSE], x1$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "num_2" is missing.
 
 ---
@@ -43,7 +43,7 @@
     Code
       forge(example_train[, 1, drop = FALSE], x2$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "num_2" is missing.
 
 ---
@@ -51,7 +51,7 @@
     Code
       forge(example_train[, 3, drop = FALSE], x1$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required columns "num_1" and "num_2" are missing.
 
 ---
@@ -59,7 +59,7 @@
     Code
       forge(example_train[, 3, drop = FALSE], x2$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required columns "num_1" and "num_2" are missing.
 
 # novel predictor levels are caught

--- a/tests/testthat/_snaps/forge-recipe.md
+++ b/tests/testthat/_snaps/forge-recipe.md
@@ -3,7 +3,7 @@
     Code
       forge(iris2, x1$blueprint, outcomes = TRUE)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Species" is missing.
 
 ---
@@ -11,7 +11,7 @@
     Code
       forge(iris2, x2$blueprint, outcomes = TRUE)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Species" is missing.
 
 # missing predictor columns fail appropriately
@@ -19,7 +19,7 @@
     Code
       forge(iris[, 1, drop = FALSE], x$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Sepal.Width" is missing.
 
 ---
@@ -27,7 +27,7 @@
     Code
       forge(iris[, 3, drop = FALSE], x$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required columns "Sepal.Length" and "Sepal.Width" are missing.
 
 # novel predictor levels are caught
@@ -89,7 +89,7 @@
     Code
       forge(iris, x$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Sepal.Width" is missing.
 
 # `NA` roles are treated as extra roles that are required at `forge()` time
@@ -97,7 +97,7 @@
     Code
       forge(iris, x$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Petal.Length" is missing.
 
 # `forge()` is compatible with hardhat 0.2.0 molded blueprints with a basic recipe
@@ -105,7 +105,7 @@
     Code
       forge(new_data, blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "x" is missing.
 
 # `forge()` is compatible with hardhat 0.2.0 molded blueprints with a recipe with a nonstandard role
@@ -113,6 +113,6 @@
     Code
       forge(new_data, blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "id" is missing.
 

--- a/tests/testthat/_snaps/forge-xy.md
+++ b/tests/testthat/_snaps/forge-xy.md
@@ -3,7 +3,7 @@
     Code
       forge(iris, x1$blueprint, outcomes = TRUE)
     Condition
-      Error in `validate_missing_name_isnt_.outcome()`:
+      Error in `forge()`:
       ! The following required columns are missing: ".outcome".
       i This indicates that `mold()` was called with a vector for `y`.
       i When this is the case, and the outcome columns are requested in `forge()`, `new_data` must include a column with the automatically generated name, `.outcome`, containing the outcome.
@@ -13,7 +13,7 @@
     Code
       forge(iris, x2$blueprint, outcomes = TRUE)
     Condition
-      Error in `validate_missing_name_isnt_.outcome()`:
+      Error in `forge()`:
       ! The following required columns are missing: ".outcome".
       i This indicates that `mold()` was called with a vector for `y`.
       i When this is the case, and the outcome columns are requested in `forge()`, `new_data` must include a column with the automatically generated name, `.outcome`, containing the outcome.

--- a/tests/testthat/_snaps/forge-xy.md
+++ b/tests/testthat/_snaps/forge-xy.md
@@ -47,7 +47,7 @@
     Code
       forge(iris[, 1, drop = FALSE], x1$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Sepal.Width" is missing.
 
 ---
@@ -55,7 +55,7 @@
     Code
       forge(iris[, 1, drop = FALSE], x2$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Sepal.Width" is missing.
 
 ---
@@ -63,7 +63,7 @@
     Code
       forge(iris[, 3, drop = FALSE], x1$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required columns "Sepal.Length" and "Sepal.Width" are missing.
 
 ---
@@ -71,7 +71,7 @@
     Code
       forge(iris[, 3, drop = FALSE], x2$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required columns "Sepal.Length" and "Sepal.Width" are missing.
 
 # novel predictor levels are caught

--- a/tests/testthat/_snaps/model-offset.md
+++ b/tests/testthat/_snaps/model-offset.md
@@ -3,7 +3,7 @@
     Code
       mold(~ Sepal.Width + offset(Species), iris)
     Condition
-      Error in `model_offset()`:
+      Error in `mold()`:
       ! Column "offset(Species)" is tagged as an offset and thus must be numeric, not a <factor> object.
 
 # offset columns are stored as predictors

--- a/tests/testthat/_snaps/model-offset.md
+++ b/tests/testthat/_snaps/model-offset.md
@@ -11,6 +11,6 @@
     Code
       forge(iris2, x$blueprint)
     Condition
-      Error in `validate_column_names()`:
+      Error in `forge()`:
       ! The required column "Sepal.Length" is missing.
 

--- a/tests/testthat/_snaps/mold-formula.md
+++ b/tests/testthat/_snaps/mold-formula.md
@@ -167,7 +167,7 @@
     Code
       mold(fac_1 ~ y + 0, example_train)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term: `+ 0` or `0 +`.
 
 ---
@@ -175,7 +175,7 @@
     Code
       mold(fac_1 ~ y + 0, example_train, blueprint = bp)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term: `+ 0` or `0 +`.
 
 ---
@@ -183,7 +183,7 @@
     Code
       mold(fac_1 ~ 0 + y, example_train)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term: `+ 0` or `0 +`.
 
 ---
@@ -191,7 +191,7 @@
     Code
       mold(fac_1 ~ y - 1, example_train)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term: `- 1`.
 
 # RHS with _only_ intercept related terms are caught
@@ -199,7 +199,7 @@
     Code
       mold(~0, example_train)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term, `0`.
 
 ---
@@ -207,7 +207,7 @@
     Code
       mold(~0, example_train, blueprint = bp)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term, `0`.
 
 ---
@@ -215,7 +215,7 @@
     Code
       mold(~1, example_train)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept term, `1`.
 
 ---
@@ -223,7 +223,7 @@
     Code
       mold(~ -1, example_train)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term: `- 1`.
 
 # `NULL` can be used to represent empty RHS formulas
@@ -231,7 +231,7 @@
     Code
       mold(~0, example_train)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term, `0`.
 
 ---
@@ -239,7 +239,7 @@
     Code
       mold(~0, example_train, blueprint = bp)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `formula` must not contain the intercept removal term, `0`.
 
 # `data` is validated
@@ -247,7 +247,7 @@
     Code
       mold(fac_1 ~ num_2, 1)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `data` must be a data frame or a matrix, not the number 1.
 
 ---
@@ -255,7 +255,7 @@
     Code
       mold(fac_1 ~ num_2, 1, blueprint = bp)
     Condition
-      Error in `mold_formula_default_clean()`:
+      Error in `mold()`:
       ! `data` must be a data frame or a matrix, not the number 1.
 
 # LHS of the formula cannot contain interactions

--- a/tests/testthat/_snaps/mold-formula.md
+++ b/tests/testthat/_snaps/mold-formula.md
@@ -126,7 +126,7 @@
     Code
       mold(fac_1 ~ y + z, example_train)
     Condition
-      Error in `get_all_predictors()`:
+      Error in `mold()`:
       ! The following predictors were not found in `data`: "y" and "z".
 
 ---
@@ -134,7 +134,7 @@
     Code
       mold(fac_1 ~ y + z, example_train, blueprint = bp)
     Condition
-      Error in `get_all_predictors()`:
+      Error in `mold()`:
       ! The following predictors were not found in `data`: "y" and "z".
 
 ---
@@ -159,7 +159,7 @@
       y <- 1
       mold(fac_1 ~ y, example_train)
     Condition
-      Error in `get_all_predictors()`:
+      Error in `mold()`:
       ! The following predictor was not found in `data`: "y".
 
 # cannot manually remove intercept in the formula itself

--- a/tests/testthat/_snaps/mold-formula.md
+++ b/tests/testthat/_snaps/mold-formula.md
@@ -263,7 +263,7 @@
     Code
       mold(num_1:num_2 ~ num_2, example_train)
     Condition
-      Error in `mold_formula_default_process_outcomes()`:
+      Error in `mold()`:
       ! Interaction terms can't be specified on the LHS of `formula`.
       i The following interaction term was found: `num_1:num_2`.
 
@@ -272,7 +272,7 @@
     Code
       mold(num_1 * num_2 ~ num_2, example_train)
     Condition
-      Error in `mold_formula_default_process_outcomes()`:
+      Error in `mold()`:
       ! Interaction terms can't be specified on the LHS of `formula`.
       i The following interaction term was found: `num_1 * num_2`.
 
@@ -281,7 +281,7 @@
     Code
       mold(num_1 %in% num_2 ~ num_2, example_train)
     Condition
-      Error in `mold_formula_default_process_outcomes()`:
+      Error in `mold()`:
       ! Interaction terms can't be specified on the LHS of `formula`.
       i The following interaction term was found: `num_1 %in% num_2`.
 
@@ -290,7 +290,7 @@
     Code
       mold((num_1 + num_2)^2 ~ num_2, example_train)
     Condition
-      Error in `mold_formula_default_process_outcomes()`:
+      Error in `mold()`:
       ! Interaction terms can't be specified on the LHS of `formula`.
       i The following interaction term was found: `(num_1 + num_2)^2`.
 
@@ -299,7 +299,7 @@
     Code
       mold(num_1:num_2 + fac_1:num_1 ~ num_2, example_train)
     Condition
-      Error in `mold_formula_default_process_outcomes()`:
+      Error in `mold()`:
       ! Interaction terms can't be specified on the LHS of `formula`.
       i The following interaction term was found: `num_1:num_2`.
 
@@ -308,7 +308,7 @@
     Code
       mold(num_1 / num_2 ~ num_2, example_train)
     Condition
-      Error in `mold_formula_default_process_outcomes()`:
+      Error in `mold()`:
       ! Interaction terms can't be specified on the LHS of `formula`.
       i The following interaction term was found: `num_1/num_2`.
 

--- a/tests/testthat/_snaps/mold-formula.md
+++ b/tests/testthat/_snaps/mold-formula.md
@@ -142,7 +142,7 @@
     Code
       mold(y + z ~ fac_1, example_train)
     Condition
-      Error in `get_all_outcomes()`:
+      Error in `mold()`:
       ! The following outcomes were not found in `data`: "y" and "z".
 
 ---
@@ -150,7 +150,7 @@
     Code
       mold(y + z ~ fac_1, example_train, blueprint = bp)
     Condition
-      Error in `get_all_outcomes()`:
+      Error in `mold()`:
       ! The following outcomes were not found in `data`: "y" and "z".
 
 # global environment variables cannot be used
@@ -317,7 +317,7 @@
     Code
       mold(. ~ fac_1, example_train)
     Condition
-      Error in `get_all_outcomes()`:
+      Error in `mold()`:
       ! The left-hand side of the formula cannot contain `.`.
 
 ---
@@ -325,7 +325,7 @@
     Code
       mold(. ~ fac_1, example_train, blueprint = bp)
     Condition
-      Error in `get_all_outcomes()`:
+      Error in `mold()`:
       ! The left-hand side of the formula cannot contain `.`.
 
 # `blueprint` is validated

--- a/tests/testthat/_snaps/mold-formula.md
+++ b/tests/testthat/_snaps/mold-formula.md
@@ -4,7 +4,7 @@
       mold(num_1 ~ fac_1:num_2, example_train, blueprint = default_formula_blueprint(
         indicators = "none"))
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Interaction terms involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Interactions terms involving factors were detected for "fac_1" in `fac_1:num_2`.
 
@@ -14,7 +14,7 @@
       mold(num_1 ~ fac_1:num_2, example_train, blueprint = default_formula_blueprint(
         indicators = "none"))
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Interaction terms involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Interactions terms involving factors were detected for "fac_1" in `fac_1:num_2`.
 
@@ -24,7 +24,7 @@
       mold(num_1 ~ fac_1 * num_2, example_train, blueprint = default_formula_blueprint(
         indicators = "none"))
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Interaction terms involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Interactions terms involving factors were detected for "fac_1" in `fac_1 * num_2`.
 
@@ -34,7 +34,7 @@
       mold(num_1 ~ (fac_1 + num_2)^2, example_train, blueprint = default_formula_blueprint(
         indicators = "none"))
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Interaction terms involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Interactions terms involving factors were detected for "fac_1" in `(fac_1 + num_2)^2`.
 
@@ -44,7 +44,7 @@
       mold(num_1 ~ fac_1 %in% num_2, example_train, blueprint = default_formula_blueprint(
         indicators = "none"))
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Interaction terms involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Interactions terms involving factors were detected for "fac_1" in `fac_1 %in% num_2`.
 
@@ -54,7 +54,7 @@
       mold(~ fac_1:fac_12, example_train2, blueprint = default_formula_blueprint(
         indicators = "none"))
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Interaction terms involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Interactions terms involving factors were detected for "fac_1" in `fac_1:fac_12`.
 
@@ -63,7 +63,7 @@
     Code
       mold(~ paste0(fac_1), example_train, blueprint = blueprint_no_indicators)
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Functions involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Functions involving factors were detected for "fac_1" in `paste0(fac_1)`.
 
@@ -72,7 +72,7 @@
     Code
       mold(~ paste0(fac_1), example_train, blueprint = blueprint_no_indicators)
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Functions involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Functions involving factors were detected for "fac_1" in `paste0(fac_1)`.
 
@@ -81,7 +81,7 @@
     Code
       mold(~ fac_1 %>% paste0(), example_train, blueprint = blueprint_no_indicators)
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Functions involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Functions involving factors were detected for "fac_1" in `fac_1 %>% paste0()`.
 
@@ -90,7 +90,7 @@
     Code
       mold(~ paste0(fac_1 + fac_1), example_train, blueprint = blueprint_no_indicators)
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Functions involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Functions involving factors were detected for "fac_1" in `fac_1 + fac_1`.
 
@@ -99,7 +99,7 @@
     Code
       mold(~ (fac_1) & num_1, example_train, blueprint = blueprint_no_indicators)
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Functions involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Functions involving factors were detected for "fac_1" in `(fac_1)`.
 
@@ -108,7 +108,7 @@
     Code
       mold(~ (fac_1 & num_1), example_train, blueprint = blueprint_no_indicators)
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Functions involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Functions involving factors were detected for "fac_1" in `fac_1 & num_1`.
 
@@ -117,7 +117,7 @@
     Code
       mold(~ paste0(fac_1) + paste0(fac_12), example_train2, blueprint = blueprint_no_indicators)
     Condition
-      Error in `mold_formula_default_process_predictors()`:
+      Error in `mold()`:
       ! Functions involving factors or characters have been detected on the RHS of `formula`. These are not allowed when `indicators = "none"`.
       i Functions involving factors were detected for "fac_1" in `paste0(fac_1)`.
 

--- a/tests/testthat/_snaps/mold-recipe.md
+++ b/tests/testthat/_snaps/mold-recipe.md
@@ -3,6 +3,6 @@
     Code
       mold(recipes::recipe(Species ~ Sepal.Length, data = iris), 1)
     Condition
-      Error in `mold_recipe_default_clean()`:
+      Error in `mold()`:
       ! `data` must be a data frame or a matrix, not the number 1.
 

--- a/tests/testthat/_snaps/recompose.md
+++ b/tests/testthat/_snaps/recompose.md
@@ -3,7 +3,7 @@
     Code
       recompose(df, composition = "matrix")
     Condition
-      Error in `recompose()`:
+      Error:
       ! `data` must only contain numeric columns.
       i These columns aren't numeric: "y" and "z".
 
@@ -12,7 +12,7 @@
     Code
       recompose(df, composition = "dgCMatrix")
     Condition
-      Error in `recompose()`:
+      Error:
       ! `data` must only contain numeric columns.
       i These columns aren't numeric: "y" and "z".
 
@@ -21,7 +21,7 @@
     Code
       recompose(1)
     Condition
-      Error in `recompose()`:
+      Error:
       ! `data` must be a data frame, not the number 1.
 
 # dots must be empty
@@ -40,7 +40,7 @@
     Code
       recompose(data.frame(), composition = "foo")
     Condition
-      Error in `recompose()`:
+      Error:
       ! `composition` must be one of "tibble", "data.frame", "matrix", or "dgCMatrix", not "foo".
 
 ---
@@ -48,6 +48,6 @@
     Code
       recompose(data.frame(), composition = 1)
     Condition
-      Error in `recompose()`:
+      Error:
       ! `composition` must be a string or character vector.
 

--- a/tests/testthat/_snaps/standardize.md
+++ b/tests/testthat/_snaps/standardize.md
@@ -43,7 +43,7 @@
     Code
       standardize(bad2)
     Condition
-      Error in `validate_has_known_outcome_types()`:
+      Error in `standardize()`:
       ! Not all columns of `y` are known outcome types.
       i This column has an unknown type: "x".
 
@@ -52,7 +52,7 @@
     Code
       standardize(bad3)
     Condition
-      Error in `validate_has_known_outcome_types()`:
+      Error in `standardize()`:
       ! Not all columns of `y` are known outcome types.
       i These columns have unknown types: "x" and "y".
 


### PR DESCRIPTION
addresses #274

This PR passes the call down to the helper functions that show up in the snapshots. It's not attempting to follow every path up from every abort call but I figured the PR is big enough already. The snapshots cover the errors we care most about, so that's a good start.

This PR also adds a `call` argument to `validate_column_names()` and `recompose()`, as requested in #273. (The one for `weighted_table()` is still to come.)