### PR TITLE
Sending the call to `check_data_frame_or_matrix()`

### DIFF
--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -722,7 +722,8 @@ forge_formula_default_process <- function(blueprint, predictors, outcomes, extra
 
   processed <- forge_formula_default_process_outcomes(
     blueprint = blueprint,
-    outcomes = outcomes
+    outcomes = outcomes,
+    call = call
   )
 
   blueprint <- processed$blueprint
@@ -780,7 +781,8 @@ forge_formula_default_process_predictors <- function(blueprint, predictors, ...,
   )
 }
 
-forge_formula_default_process_outcomes <- function(blueprint, outcomes) {
+forge_formula_default_process_outcomes <- function(blueprint, outcomes, ..., call = caller_env()) {
+  check_dots_empty0(...)
 
   # no outcomes to process
   if (is.null(outcomes)) {
@@ -794,7 +796,7 @@ forge_formula_default_process_outcomes <- function(blueprint, outcomes) {
   terms <- blueprint$terms$outcomes
   terms <- alter_terms_environment(terms)
 
-  framed <- model_frame(terms, outcomes)
+  framed <- model_frame(terms, outcomes, call = call)
 
   # Because model.matrix() does this for the RHS and we want
   # to be consistent even though we are only going through

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -609,14 +609,14 @@ mold_formula_default_process_outcomes <- function(blueprint, data, ..., call = c
   original_names <- get_all_outcomes(formula, data, call = call)
   data <- data[original_names]
 
-  ptype <- extract_ptype(data)
+  ptype <- extract_ptype(data, call = call)
 
   formula <- get_outcomes_formula(formula)
 
   # used on the `~ LHS` formula
   check_no_interactions(formula, error_call = call)
 
-  framed <- model_frame(formula, data)
+  framed <- model_frame(formula, data, call = call)
 
   outcomes <- flatten_embedded_columns(framed$data)
 

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -750,17 +750,19 @@ forge_formula_default_process_predictors <- function(blueprint, predictors, ...,
     predictors <- mask_factorish_in_data(predictors, factorish_names)
   }
 
-  framed <- model_frame(terms, predictors)
+  framed <- model_frame(terms, predictors, call = call)
 
   if (identical(blueprint$indicators, "one_hot")) {
     data <- model_matrix_one_hot(
       terms = framed$terms,
-      data = framed$data
+      data = framed$data,
+      call = call
     )
   } else {
     data <- model_matrix(
       terms = framed$terms,
-      data = framed$data
+      data = framed$data,
+      call = call
     )
   }
 

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -537,7 +537,7 @@ mold_formula_default_process_predictors <- function(blueprint, data, ..., call =
   original_names <- get_all_predictors(formula, data, call = call)
   data <- data[original_names]
 
-  ptype <- extract_ptype(data)
+  ptype <- extract_ptype(data, call = call)
 
   if (identical(blueprint$indicators, "traditional") ||
       identical(blueprint$indicators, "one_hot")) {
@@ -566,18 +566,20 @@ mold_formula_default_process_predictors <- function(blueprint, data, ..., call =
     data <- mask_factorish_in_data(data, factorish_names)
   }
 
-  framed <- model_frame(formula, data)
+  framed <- model_frame(formula, data, call = call)
   offset <- extract_offset(framed$terms, framed$data, call = call)
 
   if (identical(blueprint$indicators, "one_hot")) {
     predictors <- model_matrix_one_hot(
       terms = framed$terms,
-      data = framed$data
+      data = framed$data,
+      call = call
     )
   } else {
     predictors <- model_matrix(
       terms = framed$terms,
-      data = framed$data
+      data = framed$data,
+      call = call
     )
   }
 

--- a/R/blueprint-formula-default.R
+++ b/R/blueprint-formula-default.R
@@ -672,7 +672,7 @@ run_forge.default_formula_blueprint <- function(blueprint,
 
 forge_formula_default_clean <- function(blueprint, new_data, outcomes, ..., call = caller_env()) {
   check_dots_empty0(...)
-  check_data_frame_or_matrix(new_data)
+  check_data_frame_or_matrix(new_data, call = call)
   new_data <- coerce_to_tibble(new_data)
   check_unique_column_names(new_data)
   check_bool(outcomes)
@@ -693,13 +693,14 @@ forge_formula_default_clean <- function(blueprint, new_data, outcomes, ..., call
   predictors <- scream(
     predictors,
     predictors_ptype,
-    allow_novel_levels = blueprint$allow_novel_levels
+    allow_novel_levels = blueprint$allow_novel_levels,
+    call = call
   )
 
   if (outcomes) {
     outcomes <- shrink(new_data, blueprint$ptypes$outcomes, call = call)
     # Never allow novel levels for outcomes
-    outcomes <- scream(outcomes, blueprint$ptypes$outcomes)
+    outcomes <- scream(outcomes, blueprint$ptypes$outcomes, call = call)
   } else {
     outcomes <- NULL
   }

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -500,7 +500,7 @@ forge_recipe_default_process <- function(blueprint, predictors, outcomes, extras
 forge_recipe_default_process_predictors <- function(blueprint, predictors, ..., call = caller_env()) {
   check_dots_empty0(...)
 
-  predictors <- maybe_add_intercept_column(predictors, blueprint$intercept)
+  predictors <- maybe_add_intercept_column(predictors, blueprint$intercept, call = call)
 
   predictors <- recompose(predictors, composition = blueprint$composition, call = call)
 

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -243,14 +243,14 @@ mold_recipe_default_process <- function(blueprint, data, ..., call = caller_env(
   predictors_ptype <- processed$ptype
   predictors_extras <- processed$extras
 
-  processed <- mold_recipe_default_process_outcomes(blueprint = blueprint, data = data)
+  processed <- mold_recipe_default_process_outcomes(blueprint = blueprint, data = data, call = call)
 
   blueprint <- processed$blueprint
   outcomes <- processed$data
   outcomes_ptype <- processed$ptype
   outcomes_extras <- processed$extras
 
-  processed <- mold_recipe_default_process_extras(blueprint, data)
+  processed <- mold_recipe_default_process_extras(blueprint, data, call = call)
 
   blueprint <- processed$blueprint
   extras <- processed$extras
@@ -277,11 +277,11 @@ mold_recipe_default_process_predictors <- function(blueprint, data, ..., call = 
 
   predictors <- recipes::juice(blueprint$recipe, all_predictors())
 
-  predictors <- maybe_add_intercept_column(predictors, blueprint$intercept)
+  predictors <- maybe_add_intercept_column(predictors, blueprint$intercept, call = call)
 
   predictors <- recompose(predictors, composition = blueprint$composition, call = call)
 
-  ptype <- get_original_predictor_ptype(blueprint$recipe, data)
+  ptype <- get_original_predictor_ptype(blueprint$recipe, data, call = call)
 
   new_mold_process_terms(
     blueprint = blueprint,
@@ -290,12 +290,14 @@ mold_recipe_default_process_predictors <- function(blueprint, data, ..., call = 
   )
 }
 
-mold_recipe_default_process_outcomes <- function(blueprint, data) {
+mold_recipe_default_process_outcomes <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   all_outcomes <- recipes::all_outcomes
 
   outcomes <- recipes::juice(blueprint$recipe, all_outcomes())
 
-  ptype <- get_original_outcome_ptype(blueprint$recipe, data)
+  ptype <- get_original_outcome_ptype(blueprint$recipe, data, call = call)
 
   new_mold_process_terms(
     blueprint = blueprint,
@@ -304,7 +306,8 @@ mold_recipe_default_process_outcomes <- function(blueprint, data) {
   )
 }
 
-mold_recipe_default_process_extras <- function(blueprint, data) {
+mold_recipe_default_process_extras <- function(blueprint, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
 
   # Capture original non standard role columns that exist in `data` and are also
   # required by the `recipe$requirements$bake` requirement. These columns are
@@ -315,7 +318,7 @@ mold_recipe_default_process_extras <- function(blueprint, data) {
   )
 
   if (!is.null(original_extra_role_cols)) {
-    original_extra_role_ptypes <- lapply(original_extra_role_cols, extract_ptype)
+    original_extra_role_ptypes <- lapply(original_extra_role_cols, extract_ptype, call = call)
 
     blueprint <- update_blueprint0(
       blueprint,
@@ -553,7 +556,9 @@ forge_recipe_default_process_extras <- function(extras,
 
 # ------------------------------------------------------------------------------
 
-get_original_predictor_ptype <- function(rec, data) {
+get_original_predictor_ptype <- function(rec, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   roles <- rec$var_info$role
   roles <- chr_explicit_na(roles)
 
@@ -562,10 +567,12 @@ get_original_predictor_ptype <- function(rec, data) {
 
   data <- data[original_names]
 
-  extract_ptype(data)
+  extract_ptype(data, call = call)
 }
 
-get_original_outcome_ptype <- function(rec, data) {
+get_original_outcome_ptype <- function(rec, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
   roles <- rec$var_info$role
   roles <- chr_explicit_na(roles)
 
@@ -573,7 +580,7 @@ get_original_outcome_ptype <- function(rec, data) {
 
   data <- data[original_names]
 
-  extract_ptype(data)
+  extract_ptype(data, call = call)
 }
 
 get_extra_role_columns_original <- function(rec, data) {

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -423,7 +423,8 @@ forge_recipe_default_clean_extras <- function(blueprint, new_data, ..., call = c
     extra_role_cols,
     blueprint$extra_role_ptypes,
     scream,
-    allow_novel_levels = blueprint$allow_novel_levels
+    allow_novel_levels = blueprint$allow_novel_levels,
+    call = call
   )
 
   extras <- list(roles = extra_role_cols)

--- a/R/blueprint-recipe-default.R
+++ b/R/blueprint-recipe-default.R
@@ -379,7 +379,7 @@ run_forge.default_recipe_blueprint <- function(blueprint,
 
 forge_recipe_default_clean <- function(blueprint, new_data, outcomes, ..., call = caller_env()) {
   check_dots_empty0(...)
-  check_data_frame_or_matrix(new_data)
+  check_data_frame_or_matrix(new_data, call = call)
   new_data <- coerce_to_tibble(new_data)
   check_unique_column_names(new_data)
   check_bool(outcomes)
@@ -389,13 +389,14 @@ forge_recipe_default_clean <- function(blueprint, new_data, outcomes, ..., call 
   predictors <- scream(
     predictors,
     blueprint$ptypes$predictors,
-    allow_novel_levels = blueprint$allow_novel_levels
+    allow_novel_levels = blueprint$allow_novel_levels,
+    call = call
   )
 
   if (outcomes) {
     outcomes <- shrink(new_data, blueprint$ptypes$outcomes, call = call)
     # Never allow novel levels for outcomes
-    outcomes <- scream(outcomes, blueprint$ptypes$outcomes)
+    outcomes <- scream(outcomes, blueprint$ptypes$outcomes, call = call)
   } else {
     outcomes <- NULL
   }

--- a/R/blueprint-xy-default.R
+++ b/R/blueprint-xy-default.R
@@ -180,7 +180,7 @@ refresh_blueprint.default_xy_blueprint <- function(blueprint) {
 run_mold.default_xy_blueprint <- function(blueprint, ..., x, y, call = caller_env()) {
   check_dots_empty0(...)
 
-  cleaned <- mold_xy_default_clean(blueprint = blueprint, x = x, y = y)
+  cleaned <- mold_xy_default_clean(blueprint = blueprint, x = x, y = y, call = call)
 
   blueprint <- cleaned$blueprint
   x <- cleaned$x
@@ -192,8 +192,10 @@ run_mold.default_xy_blueprint <- function(blueprint, ..., x, y, call = caller_en
 # ------------------------------------------------------------------------------
 # mold - xy - clean
 
-mold_xy_default_clean <- function(blueprint, x, y) {
-  cleaned <- mold_xy_default_clean_predictors(blueprint, x)
+mold_xy_default_clean <- function(blueprint, x, y, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
+  cleaned <- mold_xy_default_clean_predictors(blueprint, x, call = call)
 
   blueprint <- cleaned$blueprint
   x <- cleaned$x
@@ -211,8 +213,9 @@ mold_xy_default_clean <- function(blueprint, x, y) {
   new_mold_clean_xy(blueprint, x, y)
 }
 
-mold_xy_default_clean_predictors <- function(blueprint, x) {
-  check_data_frame_or_matrix(x)
+mold_xy_default_clean_predictors <- function(blueprint, x, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(x, call = call)
   x <- coerce_to_tibble(x)
   list(blueprint = blueprint, x = x)
 }
@@ -235,7 +238,7 @@ mold_xy_default_process <- function(blueprint, x, y, ..., call = caller_env()) {
   predictors_ptype <- processed$ptype
   predictors_extras <- processed$extras
 
-  processed <- mold_xy_default_process_outcomes(blueprint, y)
+  processed <- mold_xy_default_process_outcomes(blueprint, y, call = call)
 
   blueprint <- processed$blueprint
   outcomes <- processed$data
@@ -254,9 +257,9 @@ mold_xy_default_process_predictors <- function(blueprint, x, ..., call = caller_
   check_dots_empty0(...)
 
   # Important! Collect ptype before adding intercept!
-  ptype <- extract_ptype(x)
+  ptype <- extract_ptype(x, call = call)
 
-  x <- maybe_add_intercept_column(x, blueprint$intercept)
+  x <- maybe_add_intercept_column(x, blueprint$intercept, call = call)
 
   x <- recompose(x, composition = blueprint$composition, call = call)
 
@@ -267,8 +270,10 @@ mold_xy_default_process_predictors <- function(blueprint, x, ..., call = caller_
   )
 }
 
-mold_xy_default_process_outcomes <- function(blueprint, y) {
-  ptype <- extract_ptype(y)
+mold_xy_default_process_outcomes <- function(blueprint, y, ..., call = caller_env()) {
+  check_dots_empty0(...)
+
+  ptype <- extract_ptype(y, call = call)
 
   new_mold_process_terms(
     blueprint = blueprint,

--- a/R/blueprint-xy-default.R
+++ b/R/blueprint-xy-default.R
@@ -319,7 +319,7 @@ run_forge.default_xy_blueprint <- function(blueprint,
 
 forge_xy_default_clean <- function(blueprint, new_data, outcomes, ..., call = caller_env()) {
   check_dots_empty0(...)
-  check_data_frame_or_matrix(new_data)
+  check_data_frame_or_matrix(new_data, call = call)
   new_data <- coerce_to_tibble(new_data)
   check_unique_column_names(new_data)
   check_bool(outcomes)
@@ -329,13 +329,14 @@ forge_xy_default_clean <- function(blueprint, new_data, outcomes, ..., call = ca
   predictors <- scream(
     predictors,
     blueprint$ptypes$predictors,
-    allow_novel_levels = blueprint$allow_novel_levels
+    allow_novel_levels = blueprint$allow_novel_levels,
+    call = call
   )
 
   if (outcomes) {
     outcomes <- shrink(new_data, blueprint$ptypes$outcomes, call = call)
     # Never allow novel levels for outcomes
-    outcomes <- scream(outcomes, blueprint$ptypes$outcomes)
+    outcomes <- scream(outcomes, blueprint$ptypes$outcomes, call = call)
   } else {
     outcomes <- NULL
   }

--- a/R/blueprint-xy-default.R
+++ b/R/blueprint-xy-default.R
@@ -366,7 +366,7 @@ forge_xy_default_process <- function(blueprint, predictors, outcomes, extras, ..
 forge_xy_default_process_predictors <- function(blueprint, predictors, ..., call = caller_env()) {
   check_dots_empty0(...)
 
-  predictors <- maybe_add_intercept_column(predictors, blueprint$intercept)
+  predictors <- maybe_add_intercept_column(predictors, blueprint$intercept, call = call)
 
   predictors <- recompose(predictors, composition = blueprint$composition, call = call)
 

--- a/R/classes.R
+++ b/R/classes.R
@@ -5,6 +5,8 @@
 #' `get_data_classes()` extracts the classes from the original training data.
 #'
 #' @param data A data frame or matrix.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -24,8 +26,9 @@
 #'
 #' get_data_classes(data)
 #' @export
-get_data_classes <- function(data) {
-  data <- extract_ptype(data)
-  check_unique_column_names(data)
+get_data_classes <- function(data, ..., call = current_env()) {
+  check_dots_empty0(...)
+  data <- extract_ptype(data, call = call)
+  check_unique_column_names(data, call = call)
   lapply(data, class)
 }

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -9,6 +9,8 @@
 #'
 #' @param name The name for the intercept column. Defaults to `"(Intercept)"`,
 #' which is the same name that [stats::lm()] uses.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -21,9 +23,10 @@
 #'
 #' add_intercept_column(as.matrix(mtcars))
 #' @export
-add_intercept_column <- function(data, name = "(Intercept)") {
-  check_data_frame_or_matrix(data)
-  check_name(name)
+add_intercept_column <- function(data, name = "(Intercept)", ..., call = current_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(data, call = call)
+  check_name(name, call = call)
 
   if (name %in% colnames(data)) {
     cli::cli_warn(c(
@@ -53,10 +56,11 @@ add_intercept_column <- function(data, name = "(Intercept)") {
   }
 }
 
-maybe_add_intercept_column <- function(data, intercept = FALSE) {
+maybe_add_intercept_column <- function(data, intercept = FALSE, ..., call = caller_env()) {
+  check_dots_empty0(...)
   if (!intercept) {
     return(data)
   }
 
-  add_intercept_column(data)
+  add_intercept_column(data, call = call)
 }

--- a/R/model-frame.R
+++ b/R/model-frame.R
@@ -9,6 +9,8 @@
 #' model frame.
 #'
 #' @param data A data frame or matrix containing the terms of `formula`.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -73,9 +75,10 @@
 #'
 #' nrow(framed2$data) == nrow(iris2)
 #' @export
-model_frame <- function(formula, data) {
-  check_formula(formula)
-  check_data_frame_or_matrix(data)
+model_frame <- function(formula, data, ..., call = current_env()) {
+  check_dots_empty0(...)
+  check_formula(formula, call = call)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   frame <- with_na_pass(

--- a/R/model-matrix.R
+++ b/R/model-matrix.R
@@ -10,6 +10,8 @@
 #' @param data A tibble to construct the design matrix with. This is
 #' typically the tibble returned from the corresponding call to
 #' [model_frame()].
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @details
 #'
@@ -77,9 +79,10 @@
 #'   contrasts = global_override
 #' )
 #' @export
-model_matrix <- function(terms, data) {
-  check_terms(terms)
-  check_data_frame_or_matrix(data)
+model_matrix <- function(terms, data, ..., call = current_env()) {
+  check_dots_empty0(...)
+  check_terms(terms, call = call)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   # otherwise model.matrix() will try and run model.frame() for us on data
@@ -125,9 +128,10 @@ check_terms <- function(x,
 
 # ------------------------------------------------------------------------------
 
-model_matrix_one_hot <- function(terms, data) {
-  check_terms(terms)
-  check_data_frame_or_matrix(data)
+model_matrix_one_hot <- function(terms, data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_terms(terms, call = call)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   n_cols <- length(data)
@@ -159,7 +163,7 @@ model_matrix_one_hot <- function(terms, data) {
     data[[name]] <- assign_contrasts(col, n, contrasts)
   }
 
-  model_matrix(terms, data)
+  model_matrix(terms, data, call = call)
 }
 
 #' Contrast function for one-hot encodings

--- a/R/ptype.R
+++ b/R/ptype.R
@@ -8,6 +8,8 @@
 #' time.
 #'
 #' @param data A data frame or matrix.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -24,12 +26,14 @@
 #' hardhat:::extract_ptype(iris)
 #' @keywords internal
 #'
-extract_ptype <- function(data) {
+extract_ptype <- function(data, ..., call = current_env()) {
+  check_dots_empty0(...)
+
   if (is.null(data)) {
     return(NULL)
   }
 
-  check_data_frame_or_matrix(data)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   vec_slice(data, 0L)

--- a/R/scream.R
+++ b/R/scream.R
@@ -58,6 +58,8 @@
 #' will ignore all novel levels. This argument does not apply to ordered
 #' factors. Novel levels are not allowed in ordered factors because the
 #' level ordering is a critical part of the type.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -152,14 +154,15 @@
 #' # Novel level is kept
 #' levels(test4_kept$Species)
 #' @export
-scream <- function(data, ptype, allow_novel_levels = FALSE) {
-  vec_assert(allow_novel_levels, ptype = logical(), size = 1L)
+scream <- function(data, ptype, allow_novel_levels = FALSE, ..., call = current_env()) {
+  check_dots_empty0(...)
+  vec_assert(allow_novel_levels, ptype = logical(), size = 1L, call = call)
 
   if (is.null(data)) {
     return(NULL)
   }
 
-  check_data_frame_or_matrix(data)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   if (allow_novel_levels) {

--- a/R/shrink.R
+++ b/R/shrink.R
@@ -60,7 +60,7 @@ shrink <- function(data, ptype, ..., call = current_env()) {
     return(NULL)
   }
 
-  check_data_frame_or_matrix(data)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   cols <- colnames(ptype)

--- a/R/validation.R
+++ b/R/validation.R
@@ -589,6 +589,8 @@ validate_missing_name_isnt_.outcome <- function(missing_names, ..., call = calle
 #' [spruce_numeric()].
 #'
 #' @param new_data A data frame of new predictors and possibly outcomes.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -646,8 +648,9 @@ validate_prediction_size <- function(pred, new_data) {
 
 #' @rdname validate_prediction_size
 #' @export
-check_prediction_size <- function(pred, new_data) {
-  check_data_frame_or_matrix(new_data)
+check_prediction_size <- function(pred, new_data, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(new_data, call = call)
   new_data <- coerce_to_tibble(new_data)
 
   size_new_data <- vec_size(new_data)

--- a/R/validation.R
+++ b/R/validation.R
@@ -249,6 +249,8 @@ check_outcomes_are_factors <- function(outcomes) {
 #' with problems.
 #'
 #' @param outcomes An object to check.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -298,8 +300,9 @@ validate_outcomes_are_binary <- function(outcomes) {
 
 #' @rdname validate_outcomes_are_binary
 #' @export
-check_outcomes_are_binary <- function(outcomes) {
-  check_data_frame_or_matrix(outcomes)
+check_outcomes_are_binary <- function(outcomes, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(outcomes, call = call)
   outcomes <- coerce_to_tibble(outcomes)
 
   outcomes_levels <- map(outcomes, levels)

--- a/R/validation.R
+++ b/R/validation.R
@@ -511,7 +511,7 @@ check_predictors_are_numeric <- function(predictors, ..., call = caller_env()) {
 validate_column_names <- function(data, original_names, ..., call = current_env()) {
   check_dots_empty()
 
-  check_data_frame_or_matrix(data)
+  check_data_frame_or_matrix(data, call = call)
   data <- coerce_to_tibble(data)
 
   check <- check_column_names(data, original_names)

--- a/R/validation.R
+++ b/R/validation.R
@@ -81,6 +81,8 @@ check_outcomes_are_univariate <- function(outcomes) {
 #' and the values are the classes of the matching column.
 #'
 #' @param outcomes An object to check.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -134,8 +136,9 @@ style_bad_classes <- function(bad_classes){
 
 #' @rdname validate_outcomes_are_numeric
 #' @export
-check_outcomes_are_numeric <- function(outcomes) {
-  check_data_frame_or_matrix(outcomes)
+check_outcomes_are_numeric <- function(outcomes, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(outcomes, call = call)
   outcomes <- coerce_to_tibble(outcomes)
 
   where_numeric <- map_lgl(outcomes, is.numeric)

--- a/R/validation.R
+++ b/R/validation.R
@@ -169,6 +169,8 @@ check_outcomes_are_numeric <- function(outcomes) {
 #' and the values are the classes of the matching column.
 #'
 #' @param outcomes An object to check.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -212,8 +214,9 @@ validate_outcomes_are_factors <- function(outcomes) {
 
 #' @rdname validate_outcomes_are_factors
 #' @export
-check_outcomes_are_factors <- function(outcomes) {
-  check_data_frame_or_matrix(outcomes)
+check_outcomes_are_factors <- function(outcomes, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(outcomes, call = call)
   outcomes <- coerce_to_tibble(outcomes)
 
   where_factor <- map_lgl(outcomes, is.factor)
@@ -221,7 +224,7 @@ check_outcomes_are_factors <- function(outcomes) {
   ok <- all(where_factor)
 
   if (!ok) {
-    bad_classes <- get_data_classes(outcomes[, !where_factor])
+    bad_classes <- get_data_classes(outcomes[, !where_factor], call = call)
   } else {
     bad_classes <- list()
   }

--- a/R/validation.R
+++ b/R/validation.R
@@ -352,6 +352,8 @@ is_binary <- function(x) {
 #' and the values are the classes of the matching column.
 #'
 #' @param predictors An object to check.
+#' 
+#' @inheritParams validate_column_names
 #'
 #' @return
 #'
@@ -398,8 +400,9 @@ validate_predictors_are_numeric <- function(predictors) {
 
 #' @rdname validate_predictors_are_numeric
 #' @export
-check_predictors_are_numeric <- function(predictors) {
-  check_data_frame_or_matrix(predictors)
+check_predictors_are_numeric <- function(predictors, ..., call = caller_env()) {
+  check_dots_empty0(...)
+  check_data_frame_or_matrix(predictors, call = call)
   predictors <- coerce_to_tibble(predictors)
 
   where_numeric <- map_lgl(predictors, is.numeric)

--- a/man/add_intercept_column.Rd
+++ b/man/add_intercept_column.Rd
@@ -4,13 +4,17 @@
 \alias{add_intercept_column}
 \title{Add an intercept column to \code{data}}
 \usage{
-add_intercept_column(data, name = "(Intercept)")
+add_intercept_column(data, name = "(Intercept)", ..., call = current_env())
 }
 \arguments{
 \item{data}{A data frame or matrix.}
 
 \item{name}{The name for the intercept column. Defaults to \code{"(Intercept)"},
 which is the same name that \code{\link[stats:lm]{stats::lm()}} uses.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{data} with an intercept column.

--- a/man/extract_ptype.Rd
+++ b/man/extract_ptype.Rd
@@ -4,10 +4,14 @@
 \alias{extract_ptype}
 \title{Extract a prototype}
 \usage{
-extract_ptype(data)
+extract_ptype(data, ..., call = current_env())
 }
 \arguments{
 \item{data}{A data frame or matrix.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 A 0 row slice of \code{data} after converting it to a tibble.

--- a/man/get_data_classes.Rd
+++ b/man/get_data_classes.Rd
@@ -4,10 +4,14 @@
 \alias{get_data_classes}
 \title{Extract data classes from a data frame or matrix}
 \usage{
-get_data_classes(data)
+get_data_classes(data, ..., call = current_env())
 }
 \arguments{
 \item{data}{A data frame or matrix.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 A named list. The names are the column names of \code{data} and the values are

--- a/man/model_frame.Rd
+++ b/man/model_frame.Rd
@@ -4,13 +4,17 @@
 \alias{model_frame}
 \title{Construct a model frame}
 \usage{
-model_frame(formula, data)
+model_frame(formula, data, ..., call = current_env())
 }
 \arguments{
 \item{formula}{A formula or terms object representing the terms of the
 model frame.}
 
 \item{data}{A data frame or matrix containing the terms of \code{formula}.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 A named list with two elements:

--- a/man/model_matrix.Rd
+++ b/man/model_matrix.Rd
@@ -4,7 +4,7 @@
 \alias{model_matrix}
 \title{Construct a design matrix}
 \usage{
-model_matrix(terms, data)
+model_matrix(terms, data, ..., call = current_env())
 }
 \arguments{
 \item{terms}{A terms object to construct a model matrix with. This is
@@ -14,6 +14,10 @@ typically the terms object returned from the corresponding call to
 \item{data}{A tibble to construct the design matrix with. This is
 typically the tibble returned from the corresponding call to
 \code{\link[=model_frame]{model_frame()}}.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 A tibble containing the design matrix.

--- a/man/scream.Rd
+++ b/man/scream.Rd
@@ -4,7 +4,7 @@
 \alias{scream}
 \title{Scream}
 \usage{
-scream(data, ptype, allow_novel_levels = FALSE)
+scream(data, ptype, allow_novel_levels = FALSE, ..., call = current_env())
 }
 \arguments{
 \item{data}{A data frame containing the new data to check the structure
@@ -19,6 +19,10 @@ are found, and coerces them to \code{NA} values. Setting this argument to \code{
 will ignore all novel levels. This argument does not apply to ordered
 factors. Novel levels are not allowed in ordered factors because the
 level ordering is a critical part of the type.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 A tibble containing the required columns after any required structural

--- a/man/validate_outcomes_are_binary.Rd
+++ b/man/validate_outcomes_are_binary.Rd
@@ -7,10 +7,14 @@
 \usage{
 validate_outcomes_are_binary(outcomes)
 
-check_outcomes_are_binary(outcomes)
+check_outcomes_are_binary(outcomes, ..., call = caller_env())
 }
 \arguments{
 \item{outcomes}{An object to check.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{validate_outcomes_are_binary()} returns \code{outcomes} invisibly.

--- a/man/validate_outcomes_are_factors.Rd
+++ b/man/validate_outcomes_are_factors.Rd
@@ -7,10 +7,14 @@
 \usage{
 validate_outcomes_are_factors(outcomes)
 
-check_outcomes_are_factors(outcomes)
+check_outcomes_are_factors(outcomes, ..., call = caller_env())
 }
 \arguments{
 \item{outcomes}{An object to check.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{validate_outcomes_are_factors()} returns \code{outcomes} invisibly.

--- a/man/validate_outcomes_are_numeric.Rd
+++ b/man/validate_outcomes_are_numeric.Rd
@@ -7,10 +7,14 @@
 \usage{
 validate_outcomes_are_numeric(outcomes)
 
-check_outcomes_are_numeric(outcomes)
+check_outcomes_are_numeric(outcomes, ..., call = caller_env())
 }
 \arguments{
 \item{outcomes}{An object to check.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{validate_outcomes_are_numeric()} returns \code{outcomes} invisibly.

--- a/man/validate_prediction_size.Rd
+++ b/man/validate_prediction_size.Rd
@@ -7,7 +7,7 @@
 \usage{
 validate_prediction_size(pred, new_data)
 
-check_prediction_size(pred, new_data)
+check_prediction_size(pred, new_data, ..., call = caller_env())
 }
 \arguments{
 \item{pred}{A tibble. The predictions to return from any prediction
@@ -15,6 +15,10 @@ check_prediction_size(pred, new_data)
 \code{\link[=spruce_numeric]{spruce_numeric()}}.}
 
 \item{new_data}{A data frame of new predictors and possibly outcomes.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{validate_prediction_size()} returns \code{pred} invisibly.

--- a/man/validate_predictors_are_numeric.Rd
+++ b/man/validate_predictors_are_numeric.Rd
@@ -7,10 +7,14 @@
 \usage{
 validate_predictors_are_numeric(predictors)
 
-check_predictors_are_numeric(predictors)
+check_predictors_are_numeric(predictors, ..., call = caller_env())
 }
 \arguments{
 \item{predictors}{An object to check.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call used for errors and warnings.}
 }
 \value{
 \code{validate_predictors_are_numeric()} returns \code{predictors} invisibly.


### PR DESCRIPTION
Part of  addressing #274

This PR aims to pass all relevant calls to the `check_*()` function, which is called by the most other functions in hardhat, `check_data_frame_or_matrix()`: 53 other functions call it, with the paths to get there being made up of 85 edges. 

Notable changes along the way are the following exported functions gaining a `call` argument:
- `model_frame()`
- `model_matrix()`
- `scream()`
- `check_outcomes_are_numeric()`
- `check_outcomes_are_factors()`
- `check_outcomes_are_binary()`
- `check_predictors_are_numeric()`
- `check_prediction_size()`
- `extract_ptype()`
- `get_data_classes()`
- `add_intercept_column()`