### PR TITLE
Accept logical outcomes

### DIFF
--- a/R/standardize.R
+++ b/R/standardize.R
@@ -94,7 +94,7 @@ standardize.data.frame <- function(y) {
 }
 
 is_known_output_type <- function(x) {
-  is.numeric(x) || is.factor(x)
+  is.numeric(x) || is.factor(x) || is.logical(x)
 }
 
 validate_has_known_outcome_types <- function(y, ..., call = caller_env()) {


### PR DESCRIPTION
logical outcomes should not error on mold.data.frame(): https://github.com/tidymodels/hardhat/issues/289. This simple fix passes tests.